### PR TITLE
Add button to open context menu

### DIFF
--- a/data/emulator.js
+++ b/data/emulator.js
@@ -1792,8 +1792,8 @@ class EmulatorJS {
         const contextMenuButton = addButton("Context Menu", '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path d="M0 96C0 78.3 14.3 64 32 64H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H416c17.7 0 32 14.3 32 32z"/></svg>', () => {
             if (this.elements.contextmenu.style.display == "none") {
                 this.elements.contextmenu.style.display = "block";
-                this.elements.contextmenu.style.left = "0px";
-                this.elements.contextmenu.style.top = "0px";
+                this.elements.contextmenu.style.left = (getComputedStyle(this.elements.parent).width.split("px")[0]/2 - getComputedStyle(this.elements.contextmenu).width.split("px")[0]/2)+"px";
+                this.elements.contextmenu.style.top = (getComputedStyle(this.elements.parent).height.split("px")[0]/2 - getComputedStyle(this.elements.contextmenu).height.split("px")[0]/2)+"px";
             } else {
                 this.elements.contextmenu.style.display = "none";
             }

--- a/data/emulator.js
+++ b/data/emulator.js
@@ -1788,6 +1788,16 @@ class EmulatorJS {
         }
 
         this.elements.menu.appendChild(volumeSettings);
+
+        const contextMenuButton = addButton("Context Menu", '<svg xmlns="http://www.w3.org/2000/svg" height="16" width="14" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path d="M0 96C0 78.3 14.3 64 32 64H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H416c17.7 0 32 14.3 32 32z"/></svg>', () => {
+            if (this.elements.contextmenu.style.display == "none") {
+                this.elements.contextmenu.style.display = "block";
+                this.elements.contextmenu.style.left = "0px";
+                this.elements.contextmenu.style.top = "0px";
+            } else {
+                this.elements.contextmenu.style.display = "none";
+            }
+        });
         
         this.settingParent = this.createElement("div");
         this.settingsMenuOpen = false;
@@ -1893,6 +1903,7 @@ class EmulatorJS {
             playPause: [pauseButton, playButton],
             restart: [restartButton],
             settings: [settingButton],
+            contextMenu: [contextMenuButton],
             fullscreen: [enter, exit],
             saveState: [saveState],
             loadState: [loadState],

--- a/data/emulator.js
+++ b/data/emulator.js
@@ -1789,7 +1789,7 @@ class EmulatorJS {
 
         this.elements.menu.appendChild(volumeSettings);
 
-        const contextMenuButton = addButton("Context Menu", '<svg xmlns="http://www.w3.org/2000/svg" height="16" width="14" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path d="M0 96C0 78.3 14.3 64 32 64H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H416c17.7 0 32 14.3 32 32z"/></svg>', () => {
+        const contextMenuButton = addButton("Context Menu", '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2023 Fonticons, Inc.--><path d="M0 96C0 78.3 14.3 64 32 64H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32H416c17.7 0 32 14.3 32 32s-14.3 32-32 32H32c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32s14.3-32 32-32H416c17.7 0 32 14.3 32 32z"/></svg>', () => {
             if (this.elements.contextmenu.style.display == "none") {
                 this.elements.contextmenu.style.display = "block";
                 this.elements.contextmenu.style.left = "0px";

--- a/data/localization/Translate.html
+++ b/data/localization/Translate.html
@@ -42,6 +42,7 @@
             "Mute": "-Mute",
             "Unmute": "-Unmute",
             "Settings": "-Settings",
+            "Context Menu": "-Context Menu",
             "Enter Fullscreen": "-Enter Fullscreen",
             "Exit Fullscreen": "-Exit Fullscreen",
             "Reset": "-Reset",

--- a/data/localization/en.json
+++ b/data/localization/en.json
@@ -25,6 +25,7 @@
     "Settings": "-Settings",
     "Enter Fullscreen": "-Enter Fullscreen",
     "Exit Fullscreen": "-Exit Fullscreen",
+    "Context Menu": "-Context Menu",
     "Reset": "-Reset",
     "Clear": "-Clear",
     "Close": "-Close",


### PR DESCRIPTION
In some contexts, it's hard or impossible to open the context menu of the emulator, which is required to access important secondary options such as quick states, screen recording, and software information. Primarily, it's apparently impossible to open the context menu on a mobile web browser, since a long press on the screen is, for good reason, not registered like a right mouse click is on desktop. This commit adds what I think is the ideal solution to the issue: a button on the menu bar/drawer that opens up the context menu, without cluttering it up with multiple options, just a single new one.