### PR TITLE
Add VICE cores for C64, C128, VIC20, Plus/4, and PET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn.lock
 roms/
 data/emulator.min.js
 data/emulator.min.css
+data/cores

--- a/data/emulator.js
+++ b/data/emulator.js
@@ -89,8 +89,8 @@ class EmulatorJS {
             'c64': 'vice_x64sc',
             'c128': 'vice_x128',
             'pet': 'vice_xpet',
-            'plus4': 'vice_xplus4'
-,            'vic20': 'vice_xvic'
+            'plus4': 'vice_xplus4',
+            'vic20': 'vice_xvic'
         }
         if (this.isSafari && this.isMobile && this.getCore(true) === "n64") {
             return "parallel_n64";

--- a/data/emulator.js
+++ b/data/emulator.js
@@ -933,7 +933,7 @@ class EmulatorJS {
                 const altName = this.getBaseFileName(true);
 
                 let disableCue = false;
-                if (['pcsx_rearmed', 'genesis_plus_gx', 'picodrive', 'mednafen_pce', 'vice_x64'].includes(this.getCore()) && this.config.disableCue === undefined) {
+                if (['pcsx_rearmed', 'genesis_plus_gx', 'picodrive', 'mednafen_pce', 'vice_x64', 'vice_x64sc', 'vice_x128', 'vice_xvic', 'vice_xplus4', 'vice_xpet'].includes(this.getCore()) && this.config.disableCue === undefined) {
                     disableCue = true;
                 } else {
                     disableCue = this.config.disableCue;

--- a/data/emulator.js
+++ b/data/emulator.js
@@ -48,7 +48,11 @@ class EmulatorJS {
                 'virtualjaguar': 'jaguar',
                 'yabause': 'segaSaturn',
                 'puae': 'amiga',
-                'vice_x64': 'c64'
+                'vice_x64sc': 'c64',
+                'vice_x128': 'c128',
+                'vice_xpet': 'pet',
+                'vice_xplus4': 'plus4',
+                'vice_xvic': 'vic20'
             }
             return options[core] || core;
         }
@@ -82,7 +86,11 @@ class EmulatorJS {
             'ws': 'mednafen_wswan',
             'coleco': 'gearcoleco',
             'amiga': 'puae',
-            'c64': 'vice_x64'
+            'c64': 'vice_x64sc',
+            'c128': 'vice_x128',
+            'pet': 'vice_xpet',
+            'plus4': 'vice_xplus4'
+,            'vic20': 'vice_xvic'
         }
         if (this.isSafari && this.isMobile && this.getCore(true) === "n64") {
             return "parallel_n64";
@@ -124,6 +132,11 @@ class EmulatorJS {
         'snes9x': ['smc', 'sfc', 'swc', 'fig', 'bs', 'st'],
         'stella2014': ['a26', 'bin', 'zip'],
         'vice_x64': ['d64', 'd6z', 'd71', 'd7z', 'd80', 'd81', 'd82', 'd8z', 'g64', 'g6z', 'g41', 'g4z', 'x64', 'x6z', 'nib', 'nbz', 'd2m', 'd4m', 't64', 'tap', 'tcrt', 'prg', 'p00', 'crt', 'bin', 'cmd', 'm3u', 'vfl', 'vsf', 'zip', '7z', 'gz', '20', '40', '60', 'a0', 'b0', 'rom'],
+        'vice_x64sc': ['d64', 'd6z', 'd71', 'd7z', 'd80', 'd81', 'd82', 'd8z', 'g64', 'g6z', 'g41', 'g4z', 'x64', 'x6z', 'nib', 'nbz', 'd2m', 'd4m', 't64', 'tap', 'tcrt', 'prg', 'p00', 'crt', 'bin', 'cmd', 'm3u', 'vfl', 'vsf', 'zip', '7z', 'gz', '20', '40', '60', 'a0', 'b0', 'rom'],
+        'vice_x128': ['d64', 'd6z', 'd71', 'd7z', 'd80', 'd81', 'd82', 'd8z', 'g64', 'g6z', 'g41', 'g4z', 'x64', 'x6z', 'nib', 'nbz', 'd2m', 'd4m', 't64', 'tap', 'tcrt', 'prg', 'p00', 'crt', 'bin', 'cmd', 'm3u', 'vfl', 'vsf', 'zip', '7z', 'gz', '20', '40', '60', 'a0', 'b0', 'rom'],
+        'vice_xpet': ['d64', 'd6z', 'd71', 'd7z', 'd80', 'd81', 'd82', 'd8z', 'g64', 'g6z', 'g41', 'g4z', 'x64', 'x6z', 'nib', 'nbz', 'd2m', 'd4m', 't64', 'tap', 'tcrt', 'prg', 'p00', 'crt', 'bin', 'cmd', 'm3u', 'vfl', 'vsf', 'zip', '7z', 'gz', '20', '40', '60', 'a0', 'b0', 'rom'],
+        'vice_xplus4': ['d64', 'd6z', 'd71', 'd7z', 'd80', 'd81', 'd82', 'd8z', 'g64', 'g6z', 'g41', 'g4z', 'x64', 'x6z', 'nib', 'nbz', 'd2m', 'd4m', 't64', 'tap', 'tcrt', 'prg', 'p00', 'crt', 'bin', 'cmd', 'm3u', 'vfl', 'vsf', 'zip', '7z', 'gz', '20', '40', '60', 'a0', 'b0', 'rom'],
+        'vice_xvic': ['d64', 'd6z', 'd71', 'd7z', 'd80', 'd81', 'd82', 'd8z', 'g64', 'g6z', 'g41', 'g4z', 'x64', 'x6z', 'nib', 'nbz', 'd2m', 'd4m', 't64', 'tap', 'tcrt', 'prg', 'p00', 'crt', 'bin', 'cmd', 'm3u', 'vfl', 'vsf', 'zip', '7z', 'gz', '20', '40', '60', 'a0', 'b0', 'rom'],
         'virtualjaguar': ['j64', 'jag', 'rom', 'abs', 'cof', 'bin', 'prg'],
         'yabause': ['cue', 'iso', 'ccd', 'mds', 'chd', 'zip', 'm3u']
     }

--- a/data/emulator.js
+++ b/data/emulator.js
@@ -1,5 +1,5 @@
 class EmulatorJS {
-    version = 11; //Increase by 1 when cores are updated
+    version = 12; //Increase by 1 when cores are updated
     getCore(generic) {
         const core = this.config.system;
         /*todo:

--- a/index.html
+++ b/index.html
@@ -106,6 +106,18 @@
         </div>
 
         <script>
+            var enableDebug = false;
+            const queryString = window.location.search;
+            const urlParams = new URLSearchParams(queryString);
+            if (urlParams.get('debug') == 1)
+                enableDebug = true;
+            
+            if (enableDebug == true) {
+                console.log("Debug is enabled");
+            } else {
+                console.log("Debug is disabled");
+            }
+            
             input.onchange = async () => {
                 const url = new Blob([input.files[0]])
                 const parts = input.files[0].name.split(".")
@@ -218,7 +230,7 @@
                 window.EJS_core = core;
                 window.EJS_pathtodata = "data/";
                 window.EJS_startOnLoaded = true;
-                window.EJS_DEBUG_XX = true;
+                window.EJS_DEBUG_XX = enableDebug;
 
                 script.src = "data/loader.js";
                 document.body.appendChild(script);

--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
                 window.EJS_core = core;
                 window.EJS_pathtodata = "data/";
                 window.EJS_startOnLoaded = true;
-                window.EJS_DEBUG_XX = false;
+                window.EJS_DEBUG_XX = true;
 
                 script.src = "data/loader.js";
                 document.body.appendChild(script);

--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
                         return "coleco"
 
                     if (["d64"].includes(ext))
-                        return "vice_x64"
+                        return "vice_x64sc"
 
                     if (["nds", "gba", "gb", "z64", "n64"].includes(ext))
                         return ext
@@ -163,7 +163,11 @@
                             "SNK NeoGeo Pocket (Color)": "ngp",
                             "Bandai WonderSwan (Color)": "ws",
                             "ColecoVision": "coleco",
-                            "Commodore 64": "vice_x64"
+                            "Commodore 64": "vice_x64sc",
+                            "Commodore 128": "vice_x128",
+                            "Commodore VIC20": "vice_xvic",
+                            "Commodore Plus/4": "vice_xplus4",
+                            "Commodore PET": "vice_xpet"
                         }
 
                         const button = document.createElement("button")
@@ -206,6 +210,7 @@
                 window.EJS_core = core;
                 window.EJS_pathtodata = "data/";
                 window.EJS_startOnLoaded = true;
+                window.EJS_DEBUG_XX = false;
 
                 script.src = "data/loader.js";
                 document.body.appendChild(script);

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
                         return ext
 
                     return await new Promise(resolve => {
-                        const cores = {
+                        var coreValues = {
                             "Nintendo 64": "n64",
                             "Nintendo Game Boy": "gb",
                             "Nintendo Game Boy Advance": "gba",
@@ -169,6 +169,14 @@
                             "Commodore Plus/4": "vice_xplus4",
                             "Commodore PET": "vice_xpet"
                         }
+
+                        const cores = Object.keys(coreValues).sort().reduce(
+                            (obj, key) => { 
+                                obj[key] = coreValues[key]; 
+                                return obj;
+                            }, 
+                            {}
+                        );
 
                         const button = document.createElement("button")
                         const select = document.createElement("select")


### PR DESCRIPTION
Added support for starting the VICE cores.

Depends on https://github.com/EmulatorJS/build/pull/5

Closes https://github.com/EmulatorJS/EmulatorJS/issues/754