### PR TITLE
Fix volume slider background

### DIFF
--- a/data/emulator.css
+++ b/data/emulator.css
@@ -1202,7 +1202,6 @@
 
 .ejs_volume_parent input[type='range']::-webkit-slider-runnable-track{
     background-color:rgba(255,255,255,0.25);
-    box-shadow: 0 0 0 5px rgba(var(--ejs-primary-color), 0.5);
     outline:0;
     background: transparent;
     border:0;
@@ -1226,7 +1225,6 @@
 }
 .ejs_volume_parent input[type='range']::-moz-range-track{
     background-color:rgba(255,255,255,0.25);
-    box-shadow:0 0 0 5px rgba(var(--ejs-primary-color), 0.5);
     outline:0;
     background:transparent;
     border:0;
@@ -1252,7 +1250,6 @@
 }
 .ejs_volume_parent input[type='range']::-ms-track{
     background-color:rgba(255,255,255,0.25);
-    box-shadow:0 0 0 5px rgba(var(--ejs-primary-color), 0.5);
     outline:0;
     background:transparent;
     border:0;


### PR DESCRIPTION
As of version 1.0.6+ there has been the theme color around the volume slider:
![Screenshot 2024-02-02 094922](https://github.com/EmulatorJS/EmulatorJS/assets/74841470/57c18181-c434-4f44-9be6-575303842c1b)
It changes from this:
![Screenshot 2024-02-02 094033](https://github.com/EmulatorJS/EmulatorJS/assets/74841470/42c65eb3-3236-4400-840d-62855502b4a6)
To this:
![Screenshot 2024-02-02 094318](https://github.com/EmulatorJS/EmulatorJS/assets/74841470/16ca7a3d-32c8-4e6f-b7db-c56973e95838)
