### PR TITLE
Add support for the SMSPlus-GX core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ roms/
 data/emulator.min.js
 data/emulator.min.css
 data/cores
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 **/node_modules/
 *.db
-.vscode/settings.json
 data/minify/package-lock.json
 package-lock.json
 yarn.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "livePreview.httpHeaders": {
+        "Cross-Origin-Opener-Policy": "same-origin",
+        "Cross-Origin-Embedder-Policy": "require-corp",
+        "Accept-Ranges": "bytes"
+    }
+}

--- a/data/emulator.js
+++ b/data/emulator.js
@@ -60,7 +60,7 @@ class EmulatorJS {
             'jaguar': 'virtualjaguar',
             'lynx': 'handy',
             'segaSaturn': 'yabause',
-            'segaMS': 'genesis_plus_gx',
+            'segaMS': 'smsplus',
             'segaMD': 'genesis_plus_gx',
             'segaGG': 'genesis_plus_gx',
             'segaCD': 'genesis_plus_gx',
@@ -132,6 +132,7 @@ class EmulatorJS {
         'picodrive': ['bin', 'gen', 'smd', 'md', '32x', 'cue', 'iso', 'sms', '68k', 'chd'],
         'ppsspp': ['elf', 'iso', 'cso', 'prx', 'pbp'],
         'prosystem': ['a78', 'bin'],
+        'smsplus': ['m3u', 'mdx', 'md', 'smd', 'gen', 'bin', 'cue', 'iso', 'chd', 'bms', 'sms', 'gg', 'sg', '68k', 'sgd'],
         'snes9x': ['smc', 'sfc', 'swc', 'fig', 'bs', 'st'],
         'stella2014': ['a26', 'bin', 'zip'],
         'vice_x64': ['d64', 'd6z', 'd71', 'd7z', 'd80', 'd81', 'd82', 'd8z', 'g64', 'g6z', 'g41', 'g4z', 'x64', 'x6z', 'nib', 'nbz', 'd2m', 'd4m', 't64', 'tap', 'tcrt', 'prg', 'p00', 'crt', 'bin', 'cmd', 'm3u', 'vfl', 'vsf', 'zip', '7z', 'gz', '20', '40', '60', 'a0', 'b0', 'rom'],
@@ -944,7 +945,7 @@ class EmulatorJS {
                 const altName = this.getBaseFileName(true);
 
                 let disableCue = false;
-                if (['pcsx_rearmed', 'genesis_plus_gx', 'picodrive', 'mednafen_pce', 'vice_x64', 'vice_x64sc', 'vice_x128', 'vice_xvic', 'vice_xplus4', 'vice_xpet'].includes(this.getCore()) && this.config.disableCue === undefined) {
+                if (['pcsx_rearmed', 'genesis_plus_gx', 'picodrive', 'mednafen_pce', 'smsplus', 'vice_x64', 'vice_x64sc', 'vice_x128', 'vice_xvic', 'vice_xplus4', 'vice_xpet'].includes(this.getCore()) && this.config.disableCue === undefined) {
                     disableCue = true;
                 } else {
                     disableCue = this.config.disableCue;

--- a/index.html
+++ b/index.html
@@ -107,15 +107,25 @@
 
         <script>
             var enableDebug = false;
+            var enableThreads = false;
             const queryString = window.location.search;
             const urlParams = new URLSearchParams(queryString);
             if (urlParams.get('debug') == 1)
                 enableDebug = true;
+
+            if (urlParams.get('threads') == 1)
+                enableThreads = true;
             
             if (enableDebug == true) {
                 console.log("Debug is enabled");
             } else {
                 console.log("Debug is disabled");
+            }
+
+            if (enableThreads == true) {
+                console.log("Threads are enabled");
+            } else {
+                console.log("Threads are disabled");
             }
             
             input.onchange = async () => {
@@ -232,6 +242,7 @@
                 window.EJS_startOnLoaded = true;
                 window.EJS_DEBUG_XX = enableDebug;
                 window.EJS_disableDatabases = true;
+                window.EJS_threads = enableThreads;
 
                 script.src = "data/loader.js";
                 document.body.appendChild(script);

--- a/index.html
+++ b/index.html
@@ -106,24 +106,25 @@
         </div>
 
         <script>
-            var enableDebug = false;
-            var enableThreads = false;
+            let enableDebug = false;
+            let enableThreads = false;
             const queryString = window.location.search;
             const urlParams = new URLSearchParams(queryString);
-            if (urlParams.get('debug') == 1)
+            if (urlParams.get('debug') == 1) {
                 enableDebug = true;
-
-            if (urlParams.get('threads') == 1)
-                enableThreads = true;
-            
-            if (enableDebug == true) {
                 console.log("Debug is enabled");
             } else {
                 console.log("Debug is disabled");
             }
 
-            if (enableThreads == true) {
-                console.log("Threads are enabled");
+            if (urlParams.get('threads') == 1) {
+                if (window.SharedArrayBuffer) {
+                    enableThreads = true;
+                    console.log("Threads are enabled");
+                } else {
+                    console.warn("Threads are disabled as SharedArrayBuffer is not available. Threads requires two headers to be set when sending you html page. See https://stackoverflow.com/a/68630724");
+                    console.log("Threads are disabled");
+                }
             } else {
                 console.log("Threads are disabled");
             }


### PR DESCRIPTION
This PR adds the SMSPlus-GX core, which seems to more reliably play Sega Master System and Game Gear ROMs, than the current Genesis core.

This new core will be the default used when the segaMS alias is used.

Also added a query string parameter to enable threads: ``http://url/index.html?threads=1``

Threads will normally be disabled