### PR TITLE
Added supported Amiga file extensions - closes [Request] Add M3U support for the Amiga (and probably other platforms too) #713

### DIFF
--- a/data/emulator.js
+++ b/data/emulator.js
@@ -132,6 +132,7 @@ class EmulatorJS {
         'picodrive': ['bin', 'gen', 'smd', 'md', '32x', 'cue', 'iso', 'sms', '68k', 'chd'],
         'ppsspp': ['elf', 'iso', 'cso', 'prx', 'pbp'],
         'prosystem': ['a78', 'bin'],
+        'puae': ['adf', 'adz', 'dms', 'fdi', 'ipf', 'raw', 'hdf', 'hdz', 'lha', 'slave', 'info', 'cue', 'ccd', 'chd', 'nrg', 'mds', 'iso', 'uae', 'm3u', 'zip', '7z'],
         'smsplus': ['m3u', 'mdx', 'md', 'smd', 'gen', 'bin', 'cue', 'iso', 'chd', 'bms', 'sms', 'gg', 'sg', '68k', 'sgd'],
         'snes9x': ['smc', 'sfc', 'swc', 'fig', 'bs', 'st'],
         'stella2014': ['a26', 'bin', 'zip'],


### PR DESCRIPTION
The supported file extensions for the PUAE core weren't added, and so M3U support wasn't available.

closes #713