### PR TITLE
Disables the right click menu from displaying

### DIFF
--- a/data/emulator.js
+++ b/data/emulator.js
@@ -1293,17 +1293,6 @@ class EmulatorJS {
     createContextMenu() {
         this.elements.contextmenu = this.createElement('div');
         this.elements.contextmenu.classList.add("ejs_context_menu");
-        this.addEventListener(this.game, 'contextmenu', (e) => {
-            e.preventDefault();
-            if ((this.config.buttonOpts && this.config.buttonOpts.rightClick === false) || !this.started) return;
-            const parentRect = this.elements.parent.getBoundingClientRect();
-            this.elements.contextmenu.style.display = "block";
-            const rect = this.elements.contextmenu.getBoundingClientRect();
-            const up = e.offsetY + rect.height > parentRect.bottom - 25;
-            const left = e.offsetX + rect.width > parentRect.right - 5;
-            this.elements.contextmenu.style.left = (e.offsetX - (left ? rect.width : 0)) + "px";
-            this.elements.contextmenu.style.top = (e.offsetY - (up ? rect.height : 0)) + "px";
-        })
         const hideMenu = () => {
             this.elements.contextmenu.style.display = "none";
         }


### PR DESCRIPTION
The right click context menu that appears obscures the game canvas when playing games that use a mouse and right clicks.

The menu is still displayed when clicking the burger icon in the toolbar, so functionality is not lost - just moved.