### PR TITLE
Fixed the error of the "foreach" function in the browser.

### DIFF
--- a/data/gamepad.js
+++ b/data/gamepad.js
@@ -37,7 +37,7 @@ class GamepadHandler {
         this.timeout = setTimeout(this.loop.bind(this), 10);
     }
     updateGamepadState() {
-        const gamepads = this.getGamepads();
+        const gamepads = Array.from(this.getGamepads());
         gamepads.forEach((gamepad, index) => {
             if (!gamepad) return;
             let hasGamepad = false;


### PR DESCRIPTION
The objects traversed by the “foreach” method should be arrays, and the “Array.from()” method should be used to convert the traversal objects to arrays, ensuring that they run in some more restrictive browsers.