### PR TITLE
Fix Broken links and add new systems in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ npm start
 **[Lynx][Atari Lynx]**   | 
 **[Jaguar][Atari Jaguar]**
 
+<br>
+<br>
+
+### Commodore
+
+**[Commodore 64]** |
+**[Commodore 128]** |
+**[Commodore Amiga]**
+
+**[Commodore PET]** |
+**[Commodore Plus/4]** |
+**[Commodore VIC-20]**
 
 <br>
 <br>
@@ -148,8 +160,10 @@ npm start
     
 **[PlayStation]**   | 
 **[Arcade]**   | 
-**[3DO]**   | 
-**[MAME 2003]**
+**[3DO]**
+
+**[MAME 2003]** |
+**[ColecoVision]**
     
 </div>
 
@@ -169,7 +183,7 @@ npm start
 
 <!-- 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮   Quicklinks   🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 --->
 
-[Configurator]: https://emulatorjs.org/editor.html
+[Configurator]: https://emulatorjs.org/editor
 [Contributors]: docs/Contributors.md
 [Website]: https://emulatorjs.org/
 [Legacy]: https://coldcast.org/games/1/Super-Mario-Bros
@@ -179,36 +193,46 @@ npm start
 
 <!-- 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮  Systems  🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 -->
 
-[Nintendo Game Boy Advance]: https://emulatorjs.org/systems/Nintendo%20Game%20Boy%20Advance
-[Nintendo Game Boy]: https://emulatorjs.org/systems/Nintendo%20Game%20Boy
-[Nintendo 64]: https://emulatorjs.org/systems/Nintendo%2064
-[Nintendo DS]: https://emulatorjs.org/systems/Nintendo%20DS
+[Nintendo Game Boy Advance]: https://emulatorjs.org/docs/systems/nintendo-game-boy-advance
+[Nintendo Game Boy]: https://emulatorjs.org/docs/systems/nintendo-game-boy
+[Nintendo 64]: https://emulatorjs.org/docs/systems/nintendo-64
+[Nintendo DS]: https://emulatorjs.org/docs/systems/nintendo-ds
 
-[Sega Master System]: https://emulatorjs.org/systems/Sega%20Master%20System
-[Sega Mega Drive]: https://emulatorjs.org/systems/Sega%20Mega%20Drive
-[Sega Game Gear]: https://emulatorjs.org/systems/Sega%20Game%20Gear
-[Sega Saturn]: https://emulatorjs.org/systems/Sega%20Saturn
-[Sega 32X]: https://emulatorjs.org/systems/Sega%2032X
-[Sega CD]: https://emulatorjs.org/systems/Sega%20CD
+[Sega Master System]: https://emulatorjs.org/docs/systems/sega-master-system
+[Sega Mega Drive]: https://emulatorjs.org/docs/systems/sega-mega-drive
+[Sega Game Gear]: https://emulatorjs.org/docs/systems/sega-game-gear
+[Sega Saturn]: https://emulatorjs.org/docs/systems/sega-saturn
+[Sega 32X]: https://emulatorjs.org/docs/systems/sega-32x
+[Sega CD]: https://emulatorjs.org/docs/systems/sega-cd
 
-[Atari Jaguar]: https://emulatorjs.org/systems/Atari%20Jaguar
-[Atari Lynx]: https://emulatorjs.org/systems/Atari%20Lynx
-[Atari 7800]: https://emulatorjs.org/systems/Atari%207800
-[Atari 2600]: https://emulatorjs.org/systems/Atari%202600
-[Atari 5200]: https://emulatorjs.org/systems/Atari%205200
+[Atari Jaguar]: https://emulatorjs.org/docs/systems/atari-jaguar
+[Atari Lynx]: https://emulatorjs.org/docs/systems/atari-lynx
+[Atari 7800]: https://emulatorjs.org/docs/systems/atari-7800
+[Atari 2600]: https://emulatorjs.org/docs/systems/atari-2600
+[Atari 5200]: https://emulatorjs.org/docs/systems/atari-5200
 
-[NES / Famicom]: https://emulatorjs.org/systems/NES-Famicom
-[SNES]: https://emulatorjs.org/systems/SNES
+[NES / Famicom]: https://emulatorjs.org/docs/systems/nes-famicom
+[SNES]: https://emulatorjs.org/docs/systems/snes
 
+<!--
 [TurboGrafs-16 / PC Engine]: https://emulatorjs.org/systems/TurboGrafx-16
+[MSX]: https://emulatorjs.org/systems/MSX
 [WanderSwan / Color]: https://emulatorjs.org/systems/WonderSwan
 [Neo Geo Poket]: https://emulatorjs.org/systems/Neo%20Geo%20Pocket
-[PlayStation]: https://emulatorjs.org/systems/PlayStation
-[Virtual Boy]: https://emulatorjs.org/systems/Virtual%20Boy
-[Arcade]: https://emulatorjs.org/systems/Arcade
-[MSX]: https://emulatorjs.org/systems/MSX
-[3DO]: https://emulatorjs.org/systems/3DO
-[MAME 2003]: https://emulatorjs.org/systems/MAME%202003
+--->
+[PlayStation]: https://emulatorjs.org/docs/systems/playstation
+[Virtual Boy]: https://emulatorjs.org/docs/systems/virtual-boy
+[Arcade]: https://emulatorjs.org/docs/systems/arcade
+[3DO]: https://emulatorjs.org/docs/systems/3do
+[MAME 2003]: https://emulatorjs.org/docs/systems/mame-2003
+[ColecoVision]: https://emulatorjs.org/docs/systems/colecovision
+
+[Commodore 64]: https://emulatorjs.org/docs/systems/commodore-64
+[Commodore 128]: https://emulatorjs.org/docs/systems/commodore-128
+[Commodore Amiga]: https://emulatorjs.org/docs/systems/commodore-amiga
+[Commodore PET]: https://emulatorjs.org/docs/systems/commodore-pet
+[Commodore Plus/4]: https://emulatorjs.org/docs/systems/commodore-plus4
+[Commodore VIC-20]: https://emulatorjs.org/docs/systems/commodore-vic20
 
 
 <!-- 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮  Badges  🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 🎮 --->


### PR DESCRIPTION
Changes made to the readme:
* Fixed all the broken links to the systems
* Updated the link to the Code Generator
* Added new systems

That added systems include:
* [ColecoVision](https://emulatorjs.org/docs/systems/colecovision#colecovision)
* [Commodore 64](https://emulatorjs.org/docs/systems/commodore-64#commodore-64)
* [Commodore 128](https://emulatorjs.org/docs/systems/commodore-128#commodore-128)
* [Commodore Amiga](https://emulatorjs.org/docs/systems/commodore-amiga#commodore-amiga)
* [Commodore PET](https://emulatorjs.org/docs/systems/commodore-pet#commodore-pet)
* [Commodore Plus/4](https://emulatorjs.org/docs/systems/commodore-plus4#commodore-plus4)
* [Commodore VIC-20](https://emulatorjs.org/docs/systems/commodore-vic20#commodore-vic-20)

This pr fixes #871 