### PR TITLE
Let same_cdi core handle zipped bios file directly

### DIFF
--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -782,6 +782,11 @@ class EmulatorJS {
             }
             this.textElem.innerText = this.localization("Download Game BIOS");
             const gotBios = (data) => {
+                if (this.getCore() === "same_cdi") {
+                    this.gameManager.FS.writeFile(this.config.biosUrl.split('/').pop().split("#")[0].split("?")[0], new Uint8Array(data));
+                    resolve();
+                    return;
+                }
                 this.checkCompression(new Uint8Array(data), this.localization("Decompress Game BIOS")).then((data) => {
                     for (const k in data) {
                         if (k === "!!notCompressedData") {


### PR DESCRIPTION
#878 
[same_cdi requires a zip file for the bios](https://docs.libretro.com/library/same_cdi/#bios), the core will extract the content into a specific directory.
The resulting file system structure is needed for the core to function properly.