### PR TITLE
Fix video rotation & add Arcade Core

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -33,6 +33,7 @@
             document.head.appendChild(script);
         })
     }
+    
     function loadStyle(file) {
         return new Promise(function(resolve, reject) {
             let css = document.createElement('link');

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -238,6 +238,7 @@ class EmulatorJS {
         this.canvas = this.createElement('canvas');
         this.canvas.classList.add('ejs_canvas');
         this.videoRotation = ([0, 1, 2, 3].includes(this.config.videoRotation)) ? this.config.videoRotation : this.preGetSetting("videoRotation") || 0;
+        this.videoRotationChanged = false;
         this.bindListeners();
         this.config.netplayUrl = this.config.netplayUrl || "https://netplay.emulatorjs.org";
         this.fullscreen = false;
@@ -3893,7 +3894,14 @@ class EmulatorJS {
         } else if (option === "vsync") {
             this.gameManager.setVSync(value === "enabled");
         } else if (option === "videoRotation") {
-            this.gameManager.setVideoRotation(value);
+            value = parseInt(value);
+            if (this.videoRotationChanged === true || value !== 0) {
+                this.gameManager.setVideoRotation(value);
+                this.videoRotationChanged = true;
+            } else if (this.videoRotationChanged === true && value === 0) {
+                this.gameManager.setVideoRotation(0);
+                this.videoRotationChanged = true;
+            }
         }
     }
     menuOptionChanged(option, value) {

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>EmulatorJS Demo</title>
+        <title>EmulatorJS</title>
         <link rel = icon href = docs/favicon.ico sizes = "16x16 32x32 48x48 64x64" type = image/vnd.microsoft.icon>
         <meta name = viewport content = "width = device-width, initial-scale = 1">
         <style>
@@ -181,6 +181,7 @@
                             "Sega Saturn": "segaSaturn",
                             "Atari 7800": "atari7800",
                             "Atari 2600": "atari2600",
+                            "Arcade": "arcade",
                             "NEC TurboGrafx-16/SuperGrafx/PC Engine": "pce",
                             "NEC PC-FX": "pcfx",
                             "SNK NeoGeo Pocket (Color)": "ngp",


### PR DESCRIPTION
Add the Arcade Core to the test page
Prevent video rotation unless it's needed
Fixes: #931 