### PR TITLE
Fix a bug preventing the use of background image URLs that contain parentheses

### DIFF
--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -274,7 +274,7 @@ class EmulatorJS {
         if (typeof this.config.backgroundImg === "string") {
             this.game.classList.add("ejs_game_background");
             if (this.config.backgroundBlur) this.game.classList.add("ejs_game_background_blur");
-            this.game.setAttribute("style", "--ejs-background-image: url("+this.config.backgroundImg+"); --ejs-background-color: "+this.config.backgroundColor+";");
+            this.game.setAttribute("style", `--ejs-background-image: url("${this.config.backgroundImg}"); --ejs-background-color: ${this.config.backgroundColor};`);
             this.on("start", () => {
                 this.game.classList.remove("ejs_game_background");
                 if (this.config.backgroundBlur) this.game.classList.remove("ejs_game_background_blur");


### PR DESCRIPTION
This PR fixes an issue where background image URLs that contain parentheses characters would not be parsed properly, ultimately resulting in the background image not being displayed.

Fixes #948.