### PR TITLE
Add support for Arcade BIOS files

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -115,6 +115,7 @@
     config.softLoad = window.EJS_softLoad;
     config.screenRecording = window.EJS_screenRecording;
     config.externalFiles = window.EJS_externalFiles;
+    config.dontExtractBIOS = window.EJS_dontExtractBIOS;
     config.disableDatabases = window.EJS_disableDatabases;
     config.disableLocalStorage = window.EJS_disableLocalStorage;
     config.forceLegacyCores = window.EJS_forceLegacyCores;

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -680,7 +680,7 @@ class EmulatorJS {
                 return resolve(assetUrl);
             }
             const gotData = async (input) => {
-                if (['arcade', 'mame'].includes(this.getCore(true))) {
+                if (window.EJS_dontExtractBIOS === true) {
                     this.gameManager.FS.writeFile(assetUrl, new Uint8Array(input));
                     return resolve(assetUrl);
                 }

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -680,7 +680,7 @@ class EmulatorJS {
                 return resolve(assetUrl);
             }
             const gotData = async (input) => {
-                if (window.EJS_dontExtractBIOS === true) {
+                if (this.config.dontExtractBIOS === true) {
                     this.gameManager.FS.writeFile(assetUrl, new Uint8Array(input));
                     return resolve(assetUrl);
                 }

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -682,6 +682,7 @@ class EmulatorJS {
             const gotData = async (input) => {
                 if (['arcade', 'mame'].includes(this.getCore(true))) {
                     this.gameManager.FS.writeFile(assetUrl, new Uint8Array(input));
+                    return resolve(assetUrl);
                 }
                 const data = await this.checkCompression(new Uint8Array(input), decompressProgressMessage);
                 for (const k in data) {

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -680,6 +680,9 @@ class EmulatorJS {
                 return resolve(assetUrl);
             }
             const gotData = async (input) => {
+                if (['arcade', 'mame'].includes(this.getCore(true))) {
+                    this.gameManager.FS.writeFile(assetUrl, new Uint8Array(input));
+                }
                 const data = await this.checkCompression(new Uint8Array(input), decompressProgressMessage);
                 for (const k in data) {
                     const coreFilename = "/"+this.fileName;


### PR DESCRIPTION
The default logic decompresses the BIOS file if it's a zip. 

On arcade systems, it is quite normal to have BIOS files _being_ an actual zip file. Decompressing it makes the game loading fail, as it expects to find a file named like the one we uploaded. For instance, neogeo.zip. 

This approach stores the zip file before decompressing, if it's an arcade or mame system, and then proceeds to decompressing - in case it's a zip with multiple zip files for some more complex systems with multiple drivers. 

The proper solution would be for us to allow for multiple BIOS attachments, but this compromise would work.

Please check if it doesn't break anything, but this fixes fbneo and mame2003 BIOS uploads. Tested with NeoGeo games and PGM games. If you right now try to load NeoGeo games or PGM games, for instance, it'll fail to do so - unless you add the actual BIOS files inside the rom zip file, but it doesn't do anything with the BIOS file in arcade systems.

Thanks and keep up the great work!