### PR TITLE
Need to unlink screenshot before saving

### DIFF
--- a/data/src/GameManager.js
+++ b/data/src/GameManager.js
@@ -200,6 +200,9 @@ class EJS_GameManager {
         }, 5000)
     }
     screenshot() {
+        try {
+            this.FS.unlink('screenshot.png');
+        } catch(e){}
         this.functions.screenshot();
         return new Promise(async resolve => {
             while (1) {


### PR DESCRIPTION
Found a bug where screenshots taken in succession would always lag behind by 1 screenshot. This is likely because `this.FS.stat("/screenshot.png");` would be truthy if we don't clear the existing screenshot in the `FS`. This PR attempts to fix it by first unlinking the screenshot before accessing it.