### PR TITLE
EJS_dontExtractBIOS doesn't work if BiosUrl has "/" in its path

### DIFF
--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -729,14 +729,14 @@ class EmulatorJS {
                 return resolve(assetUrl);
             }
             const gotData = async (input) => {
+                const coreFilename = "/" + this.fileName;
+                const coreFilePath = coreFilename.substring(0, coreFilename.length - coreFilename.split("/").pop().length);
                 if (this.config.dontExtractBIOS === true) {
-                    this.gameManager.FS.writeFile(assetUrl, new Uint8Array(input));
+                    this.gameManager.FS.writeFile(coreFilePath + k.split("/").pop(), new Uint8Array(input));
                     return resolve(assetUrl);
                 }
                 const data = await this.checkCompression(new Uint8Array(input), decompressProgressMessage);
                 for (const k in data) {
-                    const coreFilename = "/" + this.fileName;
-                    const coreFilePath = coreFilename.substring(0, coreFilename.length - coreFilename.split("/").pop().length);
                     if (k === "!!notCompressedData") {
                         this.gameManager.FS.writeFile(coreFilePath + assetUrl.split("/").pop().split("#")[0].split("?")[0], data[k]);
                         break;


### PR DESCRIPTION
Game doesn't load and get stuck at Download BIOS step when bios url has / in its path and EJS_dontExtractBIOS set to true.
This was due to the fact that bios path was not handled the same way than when bios was extracted