### PR TITLE
Fix screenshot return in EJS_onSaveState

### DIFF
--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -7041,11 +7041,15 @@ class EmulatorJS {
     }
 
     async takeScreenshot(source, format, upscale) {
-        return new Promise((resolve) => {
+        let blob = await new Promise((resolve) => {
             this.screenshot((blob, format) => {
-                resolve({ blob, format });
+                resolve(blob, format);
             }, source, format, upscale);
         });
+
+        const arrayBuffer = await blob.arrayBuffer();
+        const uint8 = new Uint8Array(arrayBuffer);
+        return { screenshot: uint8, format: format };
     }
 
     collectScreenRecordingMediaTracks(canvasEl, fps) {

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -7040,16 +7040,14 @@ class EmulatorJS {
         }
     }
 
-    async takeScreenshot(source, format, upscale) {
-        let blob = await new Promise((resolve) => {
-            this.screenshot((blob, format) => {
-                resolve(blob, format);
+    takeScreenshot(source, format, upscale) {
+        return new Promise((resolve) => {
+            this.screenshot(async (blob, returnFormat) => {
+                const arrayBuffer = await blob.arrayBuffer();
+                const uint8 = new Uint8Array(arrayBuffer);
+                resolve({ screenshot: uint8, format: returnFormat });
             }, source, format, upscale);
         });
-
-        const arrayBuffer = await blob.arrayBuffer();
-        const uint8 = new Uint8Array(arrayBuffer);
-        return { screenshot: uint8, format: format };
     }
 
     collectScreenRecordingMediaTracks(canvasEl, fps) {

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
             <br>
         </div>
         <div id="box">
-            <input type = file id = input>
+            <input type="file" id ="input" title="Upload" />
             Drag ROM file or click here
         </div>
 


### PR DESCRIPTION
Resolve an issue where a screenshot was not returned correctly by modifying the screenshot handling logic.

Test by adding the following to index.html:
```javascript
window.EJS_onSaveState = (e) => {
    console.log(e);
}
window.EJS_Buttons = {
    screenshotBtn: {
        visible: true,
        icon: '<svg version="1.1" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg"><g id="g3"><path d="m 256,233.109 c -28.5,0 -51.594,23.297 -51.594,52.047 0,28.766 23.094,52.047 51.594,52.047 28.5,0 51.594,-23.281 51.594,-52.047 0,-28.75 -23.094,-52.047 -51.594,-52.047 z" id="path1"/><path d="m 497.375,140.297 c -8.984,-9.094 -21.641,-14.813 -35.453,-14.813 h -54.203 c -4.359,0.016 -8.438,-2.594 -10.313,-6.813 L 381.172,82.327 C 373.141,64.311 355.281,52.593 335.469,52.593 H 176.531 c -19.813,0 -37.672,11.719 -45.719,29.719 v 0.016 l -16.219,36.344 c -1.875,4.219 -5.953,6.828 -10.313,6.813 H 50.078 c -13.813,0 -26.484,5.719 -35.484,14.813 C 5.594,149.359 0,162.031 0,175.828 v 233.25 c 0,13.797 5.594,26.469 14.594,35.531 9,9.094 21.672,14.813 35.484,14.797 h 225.781 186.063 c 13.813,0.016 26.469,-5.703 35.453,-14.797 C 506.406,435.546 512,422.875 512,409.078 v -233.25 c 0,-13.797 -5.594,-26.484 -14.625,-35.531 z m -24.094,268.781 c 0,3.313 -1.281,6.125 -3.375,8.281 -2.156,2.109 -4.844,3.328 -7.984,3.344 H 275.859 50.078 c -3.156,-0.016 -5.859,-1.234 -7.984,-3.344 -2.094,-2.156 -3.375,-4.969 -3.375,-8.281 v -233.25 c 0,-3.313 1.281,-6.125 3.375,-8.281 2.125,-2.125 4.828,-3.328 7.984,-3.344 h 54.203 c 19.781,0 37.656,-11.734 45.688,-29.766 l 16.188,-36.328 c 1.906,-4.203 5.969,-6.813 10.375,-6.813 H 335.47 c 4.406,0 8.469,2.609 10.359,6.797 l 16.219,36.359 c 8.016,18.016 25.891,29.75 45.672,29.75 h 54.203 c 3.141,0.016 5.828,1.219 7.984,3.344 2.094,2.156 3.375,4.984 3.375,8.281 v 233.251 z" id="path2"/><path d="m 256,170.938 c -31.313,-0.016 -59.75,12.844 -80.203,33.5 -20.484,20.656 -33.172,49.266 -33.156,80.719 -0.016,31.453 12.672,60.094 33.156,80.719 20.453,20.672 48.891,33.516 80.203,33.516 31.297,0 59.75,-12.844 80.203,-33.516 20.484,-20.625 33.172,-49.266 33.156,-80.719 0.016,-31.453 -12.672,-60.063 -33.156,-80.719 C 315.75,183.781 287.297,170.922 256,170.938 Z m 59.031,173.953 c -15.172,15.297 -35.953,24.688 -59.031,24.688 -23.094,0 -43.859,-9.391 -59.047,-24.688 -15.141,-15.297 -24.5,-36.328 -24.516,-59.734 0.016,-23.391 9.375,-44.422 24.516,-59.734 15.188,-15.297 35.953,-24.672 59.047,-24.688 23.078,0.016 43.859,9.391 59.031,24.688 15.156,15.313 24.516,36.344 24.531,59.734 -0.015,23.406 -9.374,44.437 -24.531,59.734 z" id="path3"/><rect x="392.18799" y="197.65601" width="34.405998" height="34.405998" id="rect3"/></g></svg>',
        displayName: 'Screenshot',
        callback: async () => { 
            console.log(await EJS_emulator.takeScreenshot(EJS_emulator.capture.photo.source, EJS_emulator.capture.photo.format, EJS_emulator.capture.photo.upscale));
        }
    }
}
```

The above code does the following:
- hook `EJS_onSaveState` to dump the response to the console
- create a take screenshot button, and dump the response to the console

_Note_: This has exposed another bug which I'm not sure how to resolve: the screenshot output style does not appear to change - options are stuck to png and canvas.