### PR TITLE
Support a fixed save flushing interval

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -126,6 +126,7 @@
     config.hideSettings = window.EJS_hideSettings;
     config.browserMode = window.EJS_browserMode;
     config.shaders = Object.assign({}, window.EJS_SHADERS, window.EJS_shaders ? window.EJS_shaders : {});
+    config.fixedSaveInterval = window.EJS_fixedSaveInterval;
 
     let systemLang;
     try {


### PR DESCRIPTION
Adds the ability for the embedder to set a fixed save interval, so that users cannot. By forcing a core to flush its saves more frequently, EmulatorJS consumers can perform operations with save more reliably.

Combined with #1094, can result in frequent save update notifications.