### PR TITLE
Improve ROM loading UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,9 +205,19 @@
                             "Commodore VIC20": "vice_xvic",
                             "Commodore Plus/4": "vice_xplus4",
                             "Commodore PET": "vice_xpet",
-                            "DOSBOX-PURE": "dosbox_pure"
+                        }
+                        
+                        if (enableThreads) {
+                            coreValues["DOSBOX-PURE"] = "dosbox_pure";
+                            coreValues["PlayStation Portable"] = "ppsspp";
                         }
 
+                        for (let core in coreValues) {
+                            if (core.toLowerCase() === ext) {
+                                resolve(core)
+                            }
+                        }
+ 
                         const cores = Object.keys(coreValues).sort().reduce(
                             (obj, key) => { 
                                 obj[key] = coreValues[key]; 


### PR DESCRIPTION
Make cores that require threads only available if threads are enabled
Make ROMs whose extensions are the name of a core use that core (i.e. rom.psx would use the psx core, and rom.atari2600 would use the atari2600 core)