### PR TITLE
beforeunload event listener update

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -127,6 +127,7 @@
     config.browserMode = window.EJS_browserMode;
     config.shaders = Object.assign({}, window.EJS_SHADERS, window.EJS_shaders ? window.EJS_shaders : {});
     config.fixedSaveInterval = window.EJS_fixedSaveInterval;
+    config.disableAutoUnload = window.EJS_disableAutoUnload;
 
     let systemLang;
     try {

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -1159,9 +1159,9 @@ class EmulatorJS {
             }, 0);
         });
         this.addEventListener(window, "beforeunload", (e) => {
-            if (window.EJS_askBeforeUnload) {
+            if (this.config.disableAutoUnload) {
                 e.preventDefault();
-                e.returnValue = '';
+                e.returnValue = "";
                 return
             } 
             if (!this.started) return;

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -1159,6 +1159,11 @@ class EmulatorJS {
             }, 0);
         });
         this.addEventListener(window, "beforeunload", (e) => {
+            if (window.EJS_askBeforeUnload) {
+                e.preventDefault();
+                e.returnValue = '';
+                return
+            } 
             if (!this.started) return;
             this.callEvent("exit");
         });

--- a/index.html
+++ b/index.html
@@ -259,7 +259,6 @@
                 window.EJS_DEBUG_XX = enableDebug;
                 window.EJS_disableDatabases = true;
                 window.EJS_threads = enableThreads;
-                window.EJS_askBeforeUnload = false;
                 if (browserMode) {
                     window.EJS_browserMode = browserMode;
                 }

--- a/index.html
+++ b/index.html
@@ -259,6 +259,7 @@
                 window.EJS_DEBUG_XX = enableDebug;
                 window.EJS_disableDatabases = true;
                 window.EJS_threads = enableThreads;
+                window.EJS_askBeforeUnload = false;
                 if (browserMode) {
                     window.EJS_browserMode = browserMode;
                 }


### PR DESCRIPTION

[issues1103](https://github.com/EmulatorJS/EmulatorJS/issues/1103) 
Thank you for your suggestion. I've tried modifying this solution, and at least it can run basically. However, there are still some flaws. After clicking confirm in the pop-up window, it's still unable to make `this.callEvent("exit")` work as expected. I've also tried using the unload event listener, but it still can't ensure that `callEvent("exit")` runs stably.

But at the very least, it doesn't alter the original operational logic. Meanwhile, when EJS_askBeforeUnload == true, it prevents accidental exits caused by made a wrong press.

If you have a better solution, I will very happy to learn from it.   :)

Thank you again