### PR TITLE
feat: Add support for dynamic cheat codes

### DIFF
--- a/data/loader.js
+++ b/data/loader.js
@@ -100,6 +100,7 @@
     config.loadState = window.EJS_loadStateURL;
     config.cacheLimit = window.EJS_CacheLimit;
     config.cheats = window.EJS_cheats;
+    config.cheatPath = window.EJS_cheatPath;
     config.defaultOptions = window.EJS_defaultOptions;
     config.gamePatchUrl = window.EJS_gamePatchUrl;
     config.gameParentUrl = window.EJS_gameParentUrl;

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -6823,271 +6823,270 @@ class EmulatorJS {
         }
     }
     createCheatsMenu() {
-    const body = this.createPopup("Cheats", {
-        "Add Cheat": () => {
-            const popups = this.createSubPopup();
-            this.cheatMenu.appendChild(popups[0]);
-            popups[1].classList.add("ejs_cheat_parent");
-            popups[1].style.width = "100%";
-            const popup = popups[1];
-            const header = this.createElement("div");
-            header.classList.add("ejs_cheat_header");
-            const title = this.createElement("h2");
-            title.innerText = this.localization("Add Cheat Code");
-            title.classList.add("ejs_cheat_heading");
-            const close = this.createElement("button");
-            close.classList.add("ejs_cheat_close");
-            header.appendChild(title);
-            header.appendChild(close);
-            popup.appendChild(header);
-            this.addEventListener(close, "click", (e) => {
-                popups[0].remove();
-            })
+        const body = this.createPopup("Cheats", {
+            "Add Cheat": () => {
+                const popups = this.createSubPopup();
+                this.cheatMenu.appendChild(popups[0]);
+                popups[1].classList.add("ejs_cheat_parent");
+                popups[1].style.width = "100%";
+                const popup = popups[1];
+                const header = this.createElement("div");
+                header.classList.add("ejs_cheat_header");
+                const title = this.createElement("h2");
+                title.innerText = this.localization("Add Cheat Code");
+                title.classList.add("ejs_cheat_heading");
+                const close = this.createElement("button");
+                close.classList.add("ejs_cheat_close");
+                header.appendChild(title);
+                header.appendChild(close);
+                popup.appendChild(header);
+                this.addEventListener(close, "click", (e) => {
+                    popups[0].remove();
+                })
 
-            let cheatDB = {};
-            const systemKey = this.getCore(true);
-            const cleanRomTags = (name) => {
-                return name.replace(/\([^)]+\)/g, '').replace(/\[[^\]]+\]/g, '').trim();
-            };
+                let cheatDB = {};
+                const systemKey = this.getCore(true);
+                const cleanRomTags = (name) => {
+                    return name.replace(/\([^)]+\)/g, '').replace(/\[[^\]]+\]/g, '').trim();
+                };
 
-            const normalizeAndConvertNumerals = (name) => {
-                let normalized = name.toLowerCase();
-                normalized = normalized.replace(/ iv/g, ' 4');
-                normalized = normalized.replace(/ iii/g, ' 3');
-                normalized = normalized.replace(/ ii/g, ' 2');
-                normalized = normalized.replace(/ v/g, ' 5');
-                normalized = normalized.replace(/ i/g, ' 1');
+                const normalizeAndConvertNumerals = (name) => {
+                    let normalized = name.toLowerCase();
+                    normalized = normalized.replace(/ iv/g, ' 4');
+                    normalized = normalized.replace(/ iii/g, ' 3');
+                    normalized = normalized.replace(/ ii/g, ' 2');
+                    normalized = normalized.replace(/ v/g, ' 5');
+                    normalized = normalized.replace(/ i/g, ' 1');
 
-                return normalized.replace(/[^a-z0-9]/g, '');
-            };
+                    return normalized.replace(/[^a-z0-9]/g, '');
+                };
 
-            const createSelect = (labelText) => {
-                const div = this.createElement("div");
-                const label = this.createElement("strong");
-                label.innerText = this.localization(labelText);
-                div.appendChild(label);
-                div.appendChild(this.createElement("br"));
-                const select = this.createElement("select");
-                select.style.width = "100%";
-                select.classList.add("ejs_cheat_code");
-                div.appendChild(select);
-                return { container: div, select: select };
-            };
+                const createSelect = (labelText) => {
+                    const div = this.createElement("div");
+                    const label = this.createElement("strong");
+                    label.innerText = this.localization(labelText);
+                    div.appendChild(label);
+                    div.appendChild(this.createElement("br"));
+                    const select = this.createElement("select");
+                    select.style.width = "100%";
+                    select.classList.add("ejs_cheat_code");
+                    div.appendChild(select);
+                    return { container: div, select: select };
+                };
 
-            const importDiv = this.createElement("div");
-            importDiv.classList.add("ejs_cheat_main");
-            importDiv.style.borderBottom = "1px solid #555";
-            importDiv.style.paddingBottom = "10px";
-            importDiv.style.display = 'none'; 
+                const importDiv = this.createElement("div");
+                importDiv.classList.add("ejs_cheat_main");
+                importDiv.style.borderBottom = "1px solid #555";
+                importDiv.style.paddingBottom = "10px";
+                importDiv.style.display = 'none';
 
-            const importTitle = this.createElement("h3");
-            importTitle.innerText = this.localization("Import from Database") + (systemKey ? ` (${systemKey.toUpperCase()})` : "");
-            importTitle.style.marginTop = "0px";
-            importDiv.appendChild(importTitle);
+                const importTitle = this.createElement("h3");
+                importTitle.innerText = this.localization("Import from Database") + (systemKey ? ` (${systemKey.toUpperCase()})` : "");
+                importTitle.style.marginTop = "0px";
+                importDiv.appendChild(importTitle);
 
-            const gameSelectUI = createSelect("Game");
-            const cheatSelectUI = createSelect("Cheat");
-            
-            importDiv.appendChild(gameSelectUI.container);
-            importDiv.appendChild(cheatSelectUI.container);
+                const gameSelectUI = createSelect("Game");
+                const cheatSelectUI = createSelect("Cheat");
 
-            popup.appendChild(importDiv);
+                importDiv.appendChild(gameSelectUI.container);
+                importDiv.appendChild(cheatSelectUI.container);
 
-            const main = this.createElement("div");
-            main.classList.add("ejs_cheat_main");
-            const header3 = this.createElement("strong");
-            header3.innerText = this.localization("Manual Entry - Code");
-            main.appendChild(header3);
-            main.appendChild(this.createElement("br"));
-            
-            const manualCodeTextarea = this.createElement("textarea");
-            manualCodeTextarea.classList.add("ejs_cheat_code");
-            manualCodeTextarea.style.width = "100%";
-            manualCodeTextarea.style.height = "80px";
-            main.appendChild(manualCodeTextarea);
-            main.appendChild(this.createElement("br"));
-            
-            const header2 = this.createElement("strong");
-            header2.innerText = this.localization("Manual Entry - Description");
-            main.appendChild(header2);
-            main.appendChild(this.createElement("br"));
-            
-            const manualDescriptionInput = this.createElement("input");
-            manualDescriptionInput.type = "text";
-            manualDescriptionInput.classList.add("ejs_cheat_code");
-            manualDescriptionInput.style.width = "100%";
-            main.appendChild(manualDescriptionInput);
-            main.appendChild(this.createElement("br"));
-            popup.appendChild(main);
+                popup.appendChild(importDiv);
 
+                const main = this.createElement("div");
+                main.classList.add("ejs_cheat_main");
+                const header3 = this.createElement("strong");
+                header3.innerText = this.localization("Manual Entry - Code");
+                main.appendChild(header3);
+                main.appendChild(this.createElement("br"));
 
-            const loadCheatList = (gameName) => {
-                cheatSelectUI.select.innerHTML = "";
-                
-                const defaultOpt = this.createElement("option");
-                defaultOpt.value = "";
-                defaultOpt.innerText = "--- " + this.localization("Select a Cheat") + " ---";
-                cheatSelectUI.select.appendChild(defaultOpt);
+                const manualCodeTextarea = this.createElement("textarea");
+                manualCodeTextarea.classList.add("ejs_cheat_code");
+                manualCodeTextarea.style.width = "100%";
+                manualCodeTextarea.style.height = "80px";
+                main.appendChild(manualCodeTextarea);
+                main.appendChild(this.createElement("br"));
 
-                manualCodeTextarea.value = "";
-                manualDescriptionInput.value = "";
-                
-                if (!gameName || !cheatDB[gameName]) return;
+                const header2 = this.createElement("strong");
+                header2.innerText = this.localization("Manual Entry - Description");
+                main.appendChild(header2);
+                main.appendChild(this.createElement("br"));
 
-                const cheats = cheatDB[gameName];
-                cheats.forEach(cheat => {
-                    const opt = this.createElement("option");
-                    opt.value = cheat.desc;
-                    opt.innerText = cheat.desc;
-                    cheatSelectUI.select.appendChild(opt);
-                });
-                
-                if (cheats.length > 0) {
-                    cheatSelectUI.select.value = cheats[0].desc;
-                    manualCodeTextarea.value = cheats[0].code;
-                    manualDescriptionInput.value = cheats[0].desc;
-                }
-            };
+                const manualDescriptionInput = this.createElement("input");
+                manualDescriptionInput.type = "text";
+                manualDescriptionInput.classList.add("ejs_cheat_code");
+                manualDescriptionInput.style.width = "100%";
+                main.appendChild(manualDescriptionInput);
+                main.appendChild(this.createElement("br"));
+                popup.appendChild(main);
 
-            const loadCheatDatabase = async (system) => {
-                gameSelectUI.select.innerHTML = "";
-                cheatSelectUI.select.innerHTML = "";
-                
-                const defaultGameOpt = this.createElement("option");
-                defaultGameOpt.value = "";
-                defaultGameOpt.innerText = "--- " + this.localization("Select a Game") + " ---";
-                gameSelectUI.select.appendChild(defaultGameOpt);
-                
-                if (!this.config.cheatPath) {
-                    if (this.debug) console.error("Cheat file load error: EJS_cheatPath is not configured.");
-                    importDiv.style.display = 'none';
-                    return;
-                }
+                const loadCheatList = (gameName) => {
+                    cheatSelectUI.select.innerHTML = "";
 
-                const url = this.config.cheatPath + system + ".json";
-                
-                try {
-                    const res = await this.downloadFile(url, null, true, { responseType: "text", method: "GET" });
-                    
-                    let data;
-                    if (res === -1) {
-                        throw new Error("Cheat JSON not found. Create a file at: " + url);
-                    } else if (typeof res.data === "string") {
-                        try {
-                            data = JSON.parse(res.data);
-                        } catch (e) {
-                            throw new Error("Failed to parse cheat JSON: " + e.message);
-                        }
-                    } else {
-                        data = res.data;
-                    }
-                    
-                    cheatDB = data;
-                    importDiv.style.display = ''; 
-                    
-                    const gameNames = Object.keys(cheatDB).sort();
-                    gameNames.forEach(name => {
-                        const opt = this.createElement("option");
-                        opt.value = name;
-                        opt.innerText = name;
-                        gameSelectUI.select.appendChild(opt);
-                    });
+                    const defaultOpt = this.createElement("option");
+                    defaultOpt.value = "";
+                    defaultOpt.innerText = "--- " + this.localization("Select a Cheat") + " ---";
+                    cheatSelectUI.select.appendChild(defaultOpt);
 
-                    let currentFileBaseName = this.getBaseFileName(true);
-                    currentFileBaseName = currentFileBaseName.replace(/\.[^/.]+$/, "");
-                    const cleanedFileName = cleanRomTags(currentFileBaseName);
-                    const normalizedFile = normalizeAndConvertNumerals(cleanedFileName);
-                    let matchedGameName = null;
-                    if (this.config.gameName && gameNames.includes(this.config.gameName)) {
-                        matchedGameName = this.config.gameName;
-                    }
-
-                    if (!matchedGameName) {
-                        for (const name of gameNames) {
-                            if (normalizeAndConvertNumerals(name) === normalizedFile) {
-                                matchedGameName = name;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (matchedGameName) {
-                        gameSelectUI.select.value = matchedGameName;
-                    }
-
-                    loadCheatList(gameSelectUI.select.value);
-
-                } catch (e) {
-                    if (this.debug) console.error("Cheat file load error:", e.message);
-                    importDiv.style.display = 'none';
-                    cheatDB = {};
-                    loadCheatList(null);
-                }
-            };
-
-            gameSelectUI.select.addEventListener("change", () => {
-                loadCheatList(gameSelectUI.select.value);
-            });
-
-            cheatSelectUI.select.addEventListener("change", () => {
-                const game = gameSelectUI.select.value;
-                const cheatDesc = cheatSelectUI.select.value;
-
-                if (!game || !cheatDesc) {
                     manualCodeTextarea.value = "";
                     manualDescriptionInput.value = "";
-                    return;
-                }
-                
-                const cheat = cheatDB[game].find(c => c.desc === cheatDesc);
-                if (cheat) {
-                    manualCodeTextarea.value = cheat.code;
-                    manualDescriptionInput.value = cheat.desc;
-                }
-            });
 
-            if (systemKey) {
-                loadCheatDatabase(systemKey).catch(e => {
-                    if (this.debug) console.error("Initial cheat load failed:", e);
+                    if (!gameName || !cheatDB[gameName]) return;
+
+                    const cheats = cheatDB[gameName];
+                    cheats.forEach(cheat => {
+                        const opt = this.createElement("option");
+                        opt.value = cheat.desc;
+                        opt.innerText = cheat.desc;
+                        cheatSelectUI.select.appendChild(opt);
+                    });
+
+                    if (cheats.length > 0) {
+                        cheatSelectUI.select.value = cheats[0].desc;
+                        manualCodeTextarea.value = cheats[0].code;
+                        manualDescriptionInput.value = cheats[0].desc;
+                    }
+                };
+
+                const loadCheatDatabase = async (system) => {
+                    gameSelectUI.select.innerHTML = "";
+                    cheatSelectUI.select.innerHTML = "";
+
+                    const defaultGameOpt = this.createElement("option");
+                    defaultGameOpt.value = "";
+                    defaultGameOpt.innerText = "--- " + this.localization("Select a Game") + " ---";
+                    gameSelectUI.select.appendChild(defaultGameOpt);
+
+                    if (!this.config.cheatPath) {
+                        if (this.debug) console.error("Cheat file load error: EJS_cheatPath is not configured.");
+                        importDiv.style.display = 'none';
+                        return;
+                    }
+
+                    const url = this.config.cheatPath + system + ".json";
+
+                    try {
+                        const res = await this.downloadFile(url, null, true, { responseType: "text", method: "GET" });
+
+                        let data;
+                        if (res === -1) {
+                            throw new Error("Cheat JSON not found. Create a file at: " + url);
+                        } else if (typeof res.data === "string") {
+                            try {
+                                data = JSON.parse(res.data);
+                            } catch (e) {
+                                throw new Error("Failed to parse cheat JSON: " + e.message);
+                            }
+                        } else {
+                            data = res.data;
+                        }
+
+                        cheatDB = data;
+                        importDiv.style.display = '';
+
+                        const gameNames = Object.keys(cheatDB).sort();
+                        gameNames.forEach(name => {
+                            const opt = this.createElement("option");
+                            opt.value = name;
+                            opt.innerText = name;
+                            gameSelectUI.select.appendChild(opt);
+                        });
+
+                        let currentFileBaseName = this.getBaseFileName(true);
+                        currentFileBaseName = currentFileBaseName.replace(/\.[^/.]+$/, "");
+                        const cleanedFileName = cleanRomTags(currentFileBaseName);
+                        const normalizedFile = normalizeAndConvertNumerals(cleanedFileName);
+                        let matchedGameName = null;
+                        if (this.config.gameName && gameNames.includes(this.config.gameName)) {
+                            matchedGameName = this.config.gameName;
+                        }
+
+                        if (!matchedGameName) {
+                            for (const name of gameNames) {
+                                if (normalizeAndConvertNumerals(name) === normalizedFile) {
+                                    matchedGameName = name;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (matchedGameName) {
+                            gameSelectUI.select.value = matchedGameName;
+                        }
+
+                        loadCheatList(gameSelectUI.select.value);
+
+                    } catch (e) {
+                        if (this.debug) console.error("Cheat file load error:", e.message);
+                        importDiv.style.display = 'none';
+                        cheatDB = {};
+                        loadCheatList(null);
+                    }
+                };
+
+                gameSelectUI.select.addEventListener("change", () => {
+                    loadCheatList(gameSelectUI.select.value);
                 });
-            } else {
-                importDiv.style.display = 'none';
-            }
 
-            const footer = this.createElement("footer");
-            const submit = this.createElement("button");
-            const closeButton = this.createElement("button");
-            submit.innerText = this.localization("Submit");
-            closeButton.innerText = this.localization("Close");
-            submit.classList.add("ejs_button_button");
-            closeButton.classList.add("ejs_button_button");
-            submit.classList.add("ejs_popup_submit");
-            closeButton.classList.add("ejs_popup_submit");
-            submit.style["background-color"] = "rgba(var(--ejs-primary-color),1)";
-            footer.appendChild(submit);
-            const span = this.createElement("span");
-            span.innerText = " ";
-            footer.appendChild(span);
-            footer.appendChild(closeButton);
-            popup.appendChild(footer);
+                cheatSelectUI.select.addEventListener("change", () => {
+                    const game = gameSelectUI.select.value;
+                    const cheatDesc = cheatSelectUI.select.value;
 
-            this.addEventListener(submit, "click", (e) => {
-                if (!manualCodeTextarea.value.trim() || !manualDescriptionInput.value.trim()) return;
-                popups[0].remove();
-                this.cheats.push({
-                    code: manualCodeTextarea.value, 
-                    desc: manualDescriptionInput.value, 
-                    checked: false
+                    if (!game || !cheatDesc) {
+                        manualCodeTextarea.value = "";
+                        manualDescriptionInput.value = "";
+                        return;
+                    }
+
+                    const cheat = cheatDB[game].find(c => c.desc === cheatDesc);
+                    if (cheat) {
+                        manualCodeTextarea.value = cheat.code;
+                        manualDescriptionInput.value = cheat.desc;
+                    }
                 });
-                this.updateCheatUI();
-                this.saveSettings();
-            })
-            this.addEventListener(closeButton, "click", (e) => {
-                popups[0].remove();
-            })
-        },
-        "Close": () => {
-            this.cheatMenu.style.display = "none";
+
+                if (systemKey) {
+                    loadCheatDatabase(systemKey).catch(e => {
+                        if (this.debug) console.error("Initial cheat load failed:", e);
+                    });
+                } else {
+                    importDiv.style.display = 'none';
+                }
+
+                const footer = this.createElement("footer");
+                const submit = this.createElement("button");
+                const closeButton = this.createElement("button");
+                submit.innerText = this.localization("Submit");
+                closeButton.innerText = this.localization("Close");
+                submit.classList.add("ejs_button_button");
+                closeButton.classList.add("ejs_button_button");
+                submit.classList.add("ejs_popup_submit");
+                closeButton.classList.add("ejs_popup_submit");
+                submit.style["background-color"] = "rgba(var(--ejs-primary-color),1)";
+                footer.appendChild(submit);
+                const span = this.createElement("span");
+                span.innerText = " ";
+                footer.appendChild(span);
+                footer.appendChild(closeButton);
+                popup.appendChild(footer);
+
+                this.addEventListener(submit, "click", (e) => {
+                    if (!manualCodeTextarea.value.trim() || !manualDescriptionInput.value.trim()) return;
+                    popups[0].remove();
+                    this.cheats.push({
+                        code: manualCodeTextarea.value,
+                        desc: manualDescriptionInput.value,
+                        checked: false
+                    });
+                    this.updateCheatUI();
+                    this.saveSettings();
+                })
+                this.addEventListener(closeButton, "click", (e) => {
+                    popups[0].remove();
+                })
+            },
+            "Close": () => {
+                this.cheatMenu.style.display = "none";
             }
         }, true);
         this.cheatMenu = body.parentElement;

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -6871,7 +6871,10 @@ class EmulatorJS {
                     select.style.width = "100%";
                     select.classList.add("ejs_cheat_code");
                     div.appendChild(select);
-                    return { container: div, select: select };
+                    return {
+                        container: div,
+                        select: select
+                    };
                 };
 
                 const importDiv = this.createElement("div");
@@ -6920,6 +6923,7 @@ class EmulatorJS {
                 main.appendChild(this.createElement("br"));
                 popup.appendChild(main);
 
+
                 const loadCheatList = (gameName) => {
                     cheatSelectUI.select.innerHTML = "";
 
@@ -6966,17 +6970,14 @@ class EmulatorJS {
                     const url = this.config.cheatPath + system + ".json";
 
                     try {
-                        const res = await this.downloadFile(url, null, true, { responseType: "text", method: "GET" });
+                        const res = await this.downloadFile(url, null, true, {
+                            responseType: "text",
+                            method: "GET"
+                        });
 
                         let data;
                         if (res === -1) {
                             throw new Error("Cheat JSON not found. Create a file at: " + url);
-                        } else if (typeof res.data === "string") {
-                            try {
-                                data = JSON.parse(res.data);
-                            } catch (e) {
-                                throw new Error("Failed to parse cheat JSON: " + e.message);
-                            }
                         } else {
                             data = res.data;
                         }

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -6843,14 +6843,24 @@ class EmulatorJS {
                 this.addEventListener(close, "click", (e) => {
                     popups[0].remove();
                 })
-                
-                // This object will hold the fetched cheat data
-                let cheatDB = {};
 
+                let cheatDB = {};
                 const systemKey = this.getCore(true);
-                const normalizeName = (name) => {
-                    return name.toLowerCase().replace(/[^a-z0-9]/g, '');
+                const cleanRomTags = (name) => {
+                    return name.replace(/\([^)]+\)/g, '').replace(/\[[^\]]+\]/g, '').trim();
                 };
+
+                const normalizeAndConvertNumerals = (name) => {
+                    let normalized = name.toLowerCase();
+                    normalized = normalized.replace(/ iv/g, ' 4'); 
+                    normalized = normalized.replace(/ iii/g, ' 3');
+                    normalized = normalized.replace(/ ii/g, ' 2');
+                    normalized = normalized.replace(/ v/g, ' 5');
+                    normalized = normalized.replace(/ i/g, ' 1'); 
+
+                    return normalized.replace(/[^a-z0-9]/g, '');
+                };
+
                 const createSelect = (labelText) => {
                     const div = this.createElement("div");
                     const label = this.createElement("strong");
@@ -6870,7 +6880,7 @@ class EmulatorJS {
                 importDiv.style.paddingBottom = "10px";
 
                 const importTitle = this.createElement("h3");
-                importTitle.innerText = this.localization("Import from Database") + ` (${systemKey.toUpperCase()})`;
+                importTitle.innerText = this.localization("Import from Database") + (systemKey ? ` (${systemKey.toUpperCase()})` : "");
                 importTitle.style.marginTop = "0px";
                 importDiv.appendChild(importTitle);
 
@@ -6888,12 +6898,13 @@ class EmulatorJS {
                 popup.appendChild(importDiv);
 
                 const loadCheatList = (gameName) => {
-                    cheatSelectUI.select.innerHTML = ""; 
+                    cheatSelectUI.select.innerHTML = "";
                     
                     const defaultOpt = this.createElement("option");
                     defaultOpt.value = "";
                     defaultOpt.innerText = "--- " + this.localization("Select a Cheat") + " ---";
                     cheatSelectUI.select.appendChild(defaultOpt);
+
                     mainText.value = "";
                     mainText2.value = "";
                     
@@ -6915,8 +6926,8 @@ class EmulatorJS {
                 };
 
                 const loadCheatDatabase = async (system) => {
-                    gameSelectUI.select.innerHTML = ""; 
-                    cheatSelectUI.select.innerHTML = ""; 
+                    gameSelectUI.select.innerHTML = "";
+                    cheatSelectUI.select.innerHTML = "";
                     errorMessage.style.display = 'none';
                     
                     const defaultGameOpt = this.createElement("option");
@@ -6958,17 +6969,19 @@ class EmulatorJS {
                             opt.innerText = name;
                             gameSelectUI.select.appendChild(opt);
                         });
-
-                        const currentFileBaseName = this.getBaseFileName(true); 
-                        const normalizedFile = normalizeName(currentFileBaseName);
+ 
+                        let currentFileBaseName = this.getBaseFileName(true);
+                        currentFileBaseName = currentFileBaseName.replace(/\.[^/.]+$/, "");
+                        const cleanedFileName = cleanRomTags(currentFileBaseName);
+                        const normalizedFile = normalizeAndConvertNumerals(cleanedFileName); 
                         let matchedGameName = null;
-                        if (gameNames.includes(this.config.gameName)) {
+                        if (this.config.gameName && gameNames.includes(this.config.gameName)) {
                             matchedGameName = this.config.gameName;
                         }
 
                         if (!matchedGameName) {
                             for (const name of gameNames) {
-                                if (normalizeName(name) === normalizedFile) {
+                                if (normalizeAndConvertNumerals(name) === normalizedFile) {
                                     matchedGameName = name;
                                     break;
                                 }

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -6823,274 +6823,271 @@ class EmulatorJS {
         }
     }
     createCheatsMenu() {
-        const body = this.createPopup("Cheats", {
-            "Add Cheat": () => {
-                const popups = this.createSubPopup();
-                this.cheatMenu.appendChild(popups[0]);
-                popups[1].classList.add("ejs_cheat_parent");
-                popups[1].style.width = "100%";
-                const popup = popups[1];
-                const header = this.createElement("div");
-                header.classList.add("ejs_cheat_header");
-                const title = this.createElement("h2");
-                title.innerText = this.localization("Add Cheat Code");
-                title.classList.add("ejs_cheat_heading");
-                const close = this.createElement("button");
-                close.classList.add("ejs_cheat_close");
-                header.appendChild(title);
-                header.appendChild(close);
-                popup.appendChild(header);
-                this.addEventListener(close, "click", (e) => {
-                    popups[0].remove();
-                })
+    const body = this.createPopup("Cheats", {
+        "Add Cheat": () => {
+            const popups = this.createSubPopup();
+            this.cheatMenu.appendChild(popups[0]);
+            popups[1].classList.add("ejs_cheat_parent");
+            popups[1].style.width = "100%";
+            const popup = popups[1];
+            const header = this.createElement("div");
+            header.classList.add("ejs_cheat_header");
+            const title = this.createElement("h2");
+            title.innerText = this.localization("Add Cheat Code");
+            title.classList.add("ejs_cheat_heading");
+            const close = this.createElement("button");
+            close.classList.add("ejs_cheat_close");
+            header.appendChild(title);
+            header.appendChild(close);
+            popup.appendChild(header);
+            this.addEventListener(close, "click", (e) => {
+                popups[0].remove();
+            })
 
-                let cheatDB = {};
-                const systemKey = this.getCore(true);
-                const cleanRomTags = (name) => {
-                    return name.replace(/\([^)]+\)/g, '').replace(/\[[^\]]+\]/g, '').trim();
-                };
+            let cheatDB = {};
+            const systemKey = this.getCore(true);
+            const cleanRomTags = (name) => {
+                return name.replace(/\([^)]+\)/g, '').replace(/\[[^\]]+\]/g, '').trim();
+            };
 
-                const normalizeAndConvertNumerals = (name) => {
-                    let normalized = name.toLowerCase();
-                    normalized = normalized.replace(/ iv/g, ' 4'); 
-                    normalized = normalized.replace(/ iii/g, ' 3');
-                    normalized = normalized.replace(/ ii/g, ' 2');
-                    normalized = normalized.replace(/ v/g, ' 5');
-                    normalized = normalized.replace(/ i/g, ' 1'); 
+            const normalizeAndConvertNumerals = (name) => {
+                let normalized = name.toLowerCase();
+                normalized = normalized.replace(/ iv/g, ' 4');
+                normalized = normalized.replace(/ iii/g, ' 3');
+                normalized = normalized.replace(/ ii/g, ' 2');
+                normalized = normalized.replace(/ v/g, ' 5');
+                normalized = normalized.replace(/ i/g, ' 1');
 
-                    return normalized.replace(/[^a-z0-9]/g, '');
-                };
+                return normalized.replace(/[^a-z0-9]/g, '');
+            };
 
-                const createSelect = (labelText) => {
-                    const div = this.createElement("div");
-                    const label = this.createElement("strong");
-                    label.innerText = this.localization(labelText);
-                    div.appendChild(label);
-                    div.appendChild(this.createElement("br"));
-                    const select = this.createElement("select");
-                    select.style.width = "100%";
-                    select.classList.add("ejs_cheat_code");
-                    div.appendChild(select);
-                    return { container: div, select: select };
-                };
+            const createSelect = (labelText) => {
+                const div = this.createElement("div");
+                const label = this.createElement("strong");
+                label.innerText = this.localization(labelText);
+                div.appendChild(label);
+                div.appendChild(this.createElement("br"));
+                const select = this.createElement("select");
+                select.style.width = "100%";
+                select.classList.add("ejs_cheat_code");
+                div.appendChild(select);
+                return { container: div, select: select };
+            };
 
-                const importDiv = this.createElement("div");
-                importDiv.classList.add("ejs_cheat_main");
-                importDiv.style.borderBottom = "1px solid #555";
-                importDiv.style.paddingBottom = "10px";
+            const importDiv = this.createElement("div");
+            importDiv.classList.add("ejs_cheat_main");
+            importDiv.style.borderBottom = "1px solid #555";
+            importDiv.style.paddingBottom = "10px";
+            importDiv.style.display = 'none'; 
 
-                const importTitle = this.createElement("h3");
-                importTitle.innerText = this.localization("Import from Database") + (systemKey ? ` (${systemKey.toUpperCase()})` : "");
-                importTitle.style.marginTop = "0px";
-                importDiv.appendChild(importTitle);
+            const importTitle = this.createElement("h3");
+            importTitle.innerText = this.localization("Import from Database") + (systemKey ? ` (${systemKey.toUpperCase()})` : "");
+            importTitle.style.marginTop = "0px";
+            importDiv.appendChild(importTitle);
 
-                const gameSelectUI = createSelect("Game");
-                const cheatSelectUI = createSelect("Cheat");
-                const errorMessage = this.createElement("div");
-                errorMessage.style.color = 'red';
-                errorMessage.style.marginTop = '5px';
-                errorMessage.style.display = 'none';
+            const gameSelectUI = createSelect("Game");
+            const cheatSelectUI = createSelect("Cheat");
+            
+            importDiv.appendChild(gameSelectUI.container);
+            importDiv.appendChild(cheatSelectUI.container);
 
-                importDiv.appendChild(gameSelectUI.container);
-                importDiv.appendChild(cheatSelectUI.container);
-                importDiv.appendChild(errorMessage);
+            popup.appendChild(importDiv);
 
-                popup.appendChild(importDiv);
+            const main = this.createElement("div");
+            main.classList.add("ejs_cheat_main");
+            const header3 = this.createElement("strong");
+            header3.innerText = this.localization("Manual Entry - Code");
+            main.appendChild(header3);
+            main.appendChild(this.createElement("br"));
+            
+            const manualCodeTextarea = this.createElement("textarea");
+            manualCodeTextarea.classList.add("ejs_cheat_code");
+            manualCodeTextarea.style.width = "100%";
+            manualCodeTextarea.style.height = "80px";
+            main.appendChild(manualCodeTextarea);
+            main.appendChild(this.createElement("br"));
+            
+            const header2 = this.createElement("strong");
+            header2.innerText = this.localization("Manual Entry - Description");
+            main.appendChild(header2);
+            main.appendChild(this.createElement("br"));
+            
+            const manualDescriptionInput = this.createElement("input");
+            manualDescriptionInput.type = "text";
+            manualDescriptionInput.classList.add("ejs_cheat_code");
+            manualDescriptionInput.style.width = "100%";
+            main.appendChild(manualDescriptionInput);
+            main.appendChild(this.createElement("br"));
+            popup.appendChild(main);
 
-                const loadCheatList = (gameName) => {
-                    cheatSelectUI.select.innerHTML = "";
-                    
-                    const defaultOpt = this.createElement("option");
-                    defaultOpt.value = "";
-                    defaultOpt.innerText = "--- " + this.localization("Select a Cheat") + " ---";
-                    cheatSelectUI.select.appendChild(defaultOpt);
 
-                    mainText.value = "";
-                    mainText2.value = "";
-                    
-                    if (!gameName || !cheatDB[gameName]) return; 
+            const loadCheatList = (gameName) => {
+                cheatSelectUI.select.innerHTML = "";
+                
+                const defaultOpt = this.createElement("option");
+                defaultOpt.value = "";
+                defaultOpt.innerText = "--- " + this.localization("Select a Cheat") + " ---";
+                cheatSelectUI.select.appendChild(defaultOpt);
 
-                    const cheats = cheatDB[gameName];
-                    cheats.forEach(cheat => {
-                        const opt = this.createElement("option");
-                        opt.value = cheat.desc;
-                        opt.innerText = cheat.desc;
-                        cheatSelectUI.select.appendChild(opt);
-                    });
-                    
-                    if (cheats.length > 0) {
-                        cheatSelectUI.select.value = cheats[0].desc;
-                        mainText.value = cheats[0].code;
-                        mainText2.value = cheats[0].desc;
-                    }
-                };
+                manualCodeTextarea.value = "";
+                manualDescriptionInput.value = "";
+                
+                if (!gameName || !cheatDB[gameName]) return;
 
-                const loadCheatDatabase = async (system) => {
-                    gameSelectUI.select.innerHTML = "";
-                    cheatSelectUI.select.innerHTML = "";
-                    errorMessage.style.display = 'none';
-                    
-                    const defaultGameOpt = this.createElement("option");
-                    defaultGameOpt.value = "";
-                    defaultGameOpt.innerText = "--- " + this.localization("Select a Game") + " ---";
-                    gameSelectUI.select.appendChild(defaultGameOpt);
-                    
-                    if (!this.config.cheatPath) {
-                        errorMessage.innerText = this.localization("Error: EJS_cheatPath is not configured.");
-                        errorMessage.style.display = 'block';
-                        return;
-                    }
-
-                    const url = this.config.cheatPath + system + ".json";
-                    
-                    try {
-                        const res = await this.downloadFile(url, null, true, { responseType: "text", method: "GET" });
-                        
-                        let data;
-                        if (res === -1) {
-                            throw new Error("Cheat JSON not found. Create a file at: " + url);
-                        } else if (typeof res.data === "string") {
-                            try {
-                                data = JSON.parse(res.data);
-                            } catch (e) {
-                                throw new Error("Failed to parse cheat JSON: " + e.message);
-                            }
-                        } else {
-                            data = res.data;
-                        }
-                        
-                        cheatDB = data;
-                        errorMessage.style.display = 'none';
-
-                        const gameNames = Object.keys(cheatDB).sort();
-                        gameNames.forEach(name => {
-                            const opt = this.createElement("option");
-                            opt.value = name;
-                            opt.innerText = name;
-                            gameSelectUI.select.appendChild(opt);
-                        });
- 
-                        let currentFileBaseName = this.getBaseFileName(true);
-                        currentFileBaseName = currentFileBaseName.replace(/\.[^/.]+$/, "");
-                        const cleanedFileName = cleanRomTags(currentFileBaseName);
-                        const normalizedFile = normalizeAndConvertNumerals(cleanedFileName); 
-                        let matchedGameName = null;
-                        if (this.config.gameName && gameNames.includes(this.config.gameName)) {
-                            matchedGameName = this.config.gameName;
-                        }
-
-                        if (!matchedGameName) {
-                            for (const name of gameNames) {
-                                if (normalizeAndConvertNumerals(name) === normalizedFile) {
-                                    matchedGameName = name;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (matchedGameName) {
-                            gameSelectUI.select.value = matchedGameName;
-                        }
-
-                        loadCheatList(gameSelectUI.select.value);
-
-                    } catch (e) {
-                        console.error("Cheat file load error:", e.message);
-                        errorMessage.innerText = this.localization("No cheat database found for ") + system.toUpperCase() + ". " + this.localization("Please use the manual entry below.");
-                        errorMessage.style.display = 'block';
-                        cheatDB = {};
-                        loadCheatList(null);
-                    }
-                };
-
-                gameSelectUI.select.addEventListener("change", () => {
-                    loadCheatList(gameSelectUI.select.value);
+                const cheats = cheatDB[gameName];
+                cheats.forEach(cheat => {
+                    const opt = this.createElement("option");
+                    opt.value = cheat.desc;
+                    opt.innerText = cheat.desc;
+                    cheatSelectUI.select.appendChild(opt);
                 });
+                
+                if (cheats.length > 0) {
+                    cheatSelectUI.select.value = cheats[0].desc;
+                    manualCodeTextarea.value = cheats[0].code;
+                    manualDescriptionInput.value = cheats[0].desc;
+                }
+            };
 
-                cheatSelectUI.select.addEventListener("change", () => {
-                    const game = gameSelectUI.select.value;
-                    const cheatDesc = cheatSelectUI.select.value;
+            const loadCheatDatabase = async (system) => {
+                gameSelectUI.select.innerHTML = "";
+                cheatSelectUI.select.innerHTML = "";
+                
+                const defaultGameOpt = this.createElement("option");
+                defaultGameOpt.value = "";
+                defaultGameOpt.innerText = "--- " + this.localization("Select a Game") + " ---";
+                gameSelectUI.select.appendChild(defaultGameOpt);
+                
+                if (!this.config.cheatPath) {
+                    if (this.debug) console.error("Cheat file load error: EJS_cheatPath is not configured.");
+                    importDiv.style.display = 'none';
+                    return;
+                }
 
-                    if (!game || !cheatDesc) {
-                         mainText.value = "";
-                         mainText2.value = "";
-                         return;
-                    }
+                const url = this.config.cheatPath + system + ".json";
+                
+                try {
+                    const res = await this.downloadFile(url, null, true, { responseType: "text", method: "GET" });
                     
-                    const cheat = cheatDB[game].find(c => c.desc === cheatDesc);
-                    if (cheat) {
-                        mainText.value = cheat.code;
-                        mainText2.value = cheat.desc;
-                    }
-                });
-
-                (async () => {
-                    if (systemKey) {
-                        await loadCheatDatabase(systemKey);
+                    let data;
+                    if (res === -1) {
+                        throw new Error("Cheat JSON not found. Create a file at: " + url);
+                    } else if (typeof res.data === "string") {
+                        try {
+                            data = JSON.parse(res.data);
+                        } catch (e) {
+                            throw new Error("Failed to parse cheat JSON: " + e.message);
+                        }
                     } else {
-                        errorMessage.innerText = this.localization("Error: Unable to determine emulator system.");
-                        errorMessage.style.display = 'block';
+                        data = res.data;
                     }
-                })();
-
-                const main = this.createElement("div");
-                main.classList.add("ejs_cheat_main");
-                const header3 = this.createElement("strong");
-                header3.innerText = this.localization("Manual Entry - Code");
-                main.appendChild(header3);
-                main.appendChild(this.createElement("br"));
-                const mainText = this.createElement("textarea");
-                mainText.classList.add("ejs_cheat_code");
-                mainText.style.width = "100%";
-                mainText.style.height = "80px";
-                main.appendChild(mainText);
-                main.appendChild(this.createElement("br"));
-                const header2 = this.createElement("strong");
-                header2.innerText = this.localization("Manual Entry - Description");
-                main.appendChild(header2);
-                main.appendChild(this.createElement("br"));
-                const mainText2 = this.createElement("input");
-                mainText2.type = "text";
-                mainText2.classList.add("ejs_cheat_code");
-                mainText2.style.width = "100%";
-                main.appendChild(mainText2);
-                main.appendChild(this.createElement("br"));
-                popup.appendChild(main);
-
-                const footer = this.createElement("footer");
-                const submit = this.createElement("button");
-                const closeButton = this.createElement("button");
-                submit.innerText = this.localization("Submit");
-                closeButton.innerText = this.localization("Close");
-                submit.classList.add("ejs_button_button");
-                closeButton.classList.add("ejs_button_button");
-                submit.classList.add("ejs_popup_submit");
-                closeButton.classList.add("ejs_popup_submit");
-                submit.style["background-color"] = "rgba(var(--ejs-primary-color),1)";
-                footer.appendChild(submit);
-                const span = this.createElement("span");
-                span.innerText = " ";
-                footer.appendChild(span);
-                footer.appendChild(closeButton);
-                popup.appendChild(footer);
-
-                this.addEventListener(submit, "click", (e) => {
-                    if (!mainText.value.trim() || !mainText2.value.trim()) return;
-                    popups[0].remove();
-                    this.cheats.push({
-                        code: mainText.value,
-                        desc: mainText2.value,
-                        checked: false
+                    
+                    cheatDB = data;
+                    importDiv.style.display = ''; 
+                    
+                    const gameNames = Object.keys(cheatDB).sort();
+                    gameNames.forEach(name => {
+                        const opt = this.createElement("option");
+                        opt.value = name;
+                        opt.innerText = name;
+                        gameSelectUI.select.appendChild(opt);
                     });
-                    this.updateCheatUI();
-                    this.saveSettings();
-                })
-                this.addEventListener(closeButton, "click", (e) => {
-                    popups[0].remove();
-                })
-            },
-            "Close": () => {
-                this.cheatMenu.style.display = "none";
+
+                    let currentFileBaseName = this.getBaseFileName(true);
+                    currentFileBaseName = currentFileBaseName.replace(/\.[^/.]+$/, "");
+                    const cleanedFileName = cleanRomTags(currentFileBaseName);
+                    const normalizedFile = normalizeAndConvertNumerals(cleanedFileName);
+                    let matchedGameName = null;
+                    if (this.config.gameName && gameNames.includes(this.config.gameName)) {
+                        matchedGameName = this.config.gameName;
+                    }
+
+                    if (!matchedGameName) {
+                        for (const name of gameNames) {
+                            if (normalizeAndConvertNumerals(name) === normalizedFile) {
+                                matchedGameName = name;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (matchedGameName) {
+                        gameSelectUI.select.value = matchedGameName;
+                    }
+
+                    loadCheatList(gameSelectUI.select.value);
+
+                } catch (e) {
+                    if (this.debug) console.error("Cheat file load error:", e.message);
+                    importDiv.style.display = 'none';
+                    cheatDB = {};
+                    loadCheatList(null);
+                }
+            };
+
+            gameSelectUI.select.addEventListener("change", () => {
+                loadCheatList(gameSelectUI.select.value);
+            });
+
+            cheatSelectUI.select.addEventListener("change", () => {
+                const game = gameSelectUI.select.value;
+                const cheatDesc = cheatSelectUI.select.value;
+
+                if (!game || !cheatDesc) {
+                    manualCodeTextarea.value = "";
+                    manualDescriptionInput.value = "";
+                    return;
+                }
+                
+                const cheat = cheatDB[game].find(c => c.desc === cheatDesc);
+                if (cheat) {
+                    manualCodeTextarea.value = cheat.code;
+                    manualDescriptionInput.value = cheat.desc;
+                }
+            });
+
+            if (systemKey) {
+                loadCheatDatabase(systemKey).catch(e => {
+                    if (this.debug) console.error("Initial cheat load failed:", e);
+                });
+            } else {
+                importDiv.style.display = 'none';
+            }
+
+            const footer = this.createElement("footer");
+            const submit = this.createElement("button");
+            const closeButton = this.createElement("button");
+            submit.innerText = this.localization("Submit");
+            closeButton.innerText = this.localization("Close");
+            submit.classList.add("ejs_button_button");
+            closeButton.classList.add("ejs_button_button");
+            submit.classList.add("ejs_popup_submit");
+            closeButton.classList.add("ejs_popup_submit");
+            submit.style["background-color"] = "rgba(var(--ejs-primary-color),1)";
+            footer.appendChild(submit);
+            const span = this.createElement("span");
+            span.innerText = " ";
+            footer.appendChild(span);
+            footer.appendChild(closeButton);
+            popup.appendChild(footer);
+
+            this.addEventListener(submit, "click", (e) => {
+                if (!manualCodeTextarea.value.trim() || !manualDescriptionInput.value.trim()) return;
+                popups[0].remove();
+                this.cheats.push({
+                    code: manualCodeTextarea.value, 
+                    desc: manualDescriptionInput.value, 
+                    checked: false
+                });
+                this.updateCheatUI();
+                this.saveSettings();
+            })
+            this.addEventListener(closeButton, "click", (e) => {
+                popups[0].remove();
+            })
+        },
+        "Close": () => {
+            this.cheatMenu.style.display = "none";
             }
         }, true);
         this.cheatMenu = body.parentElement;

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -22,7 +22,7 @@ class EmulatorJS {
             "psx": ["pcsx_rearmed", "mednafen_psx_hw"],
             "ws": ["mednafen_wswan"],
             "gba": ["mgba"],
-            "n64": ["parallel_n64", "mupen64plus_next"],
+            "n64": ["mupen64plus_next", "parallel_n64"],
             "3do": ["opera"],
             "psp": ["ppsspp"],
             "atari7800": ["prosystem"],


### PR DESCRIPTION
Adds support for dynamic cheat codes. 
Users create their own .JSONs, one per system, and add cheatPath in the config file. The path is set to the folder that stores all the .JSON files. 
When users click the existing cheats button, it will detect the game that is loaded, and if that game is in their JSON, it will list all the available cheats that the JSON has listed for that game. 
The user then clicks the cheat they want to use and the cheat description and code is automatically entered into the existing cheat fields for use. 
![attatchment 7onNnb](https://github.com/user-attachments/assets/96b41eb6-ec13-458a-9181-8c2c42b2ad64)
![attatchment vnRkz3](https://github.com/user-attachments/assets/b01c9c3e-cf8d-430e-bcd7-03d6e37af28f)
