### PR TITLE
Added automatic core detection for Sega Mega Drive games

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,6 +170,9 @@
 
                     if (["d64"].includes(ext))
                         return "vice_x64sc"
+                    
+                    if (["md", "sg", "smd", "gen"].includes(ext))
+                        return "segaMD"
 
                     if (["nds", "gba", "gb", "z64", "n64"].includes(ext))
                         return ext


### PR DESCRIPTION
Files with the extensions .md, .sg, .smd, and .gen will now automatically use the segaMD core when being loaded from the demo.