### PR TITLE
feat: add controller port device type selector

### DIFF
--- a/data/src/GameManager.js
+++ b/data/src/GameManager.js
@@ -32,7 +32,9 @@ class EJS_GameManager {
             setVSync: this.Module.cwrap("set_vsync", "null", ["number"]),
             setVideoRoation: this.Module.cwrap("set_video_rotation", "null", ["number"]),
             getVideoDimensions: this.Module.cwrap("get_video_dimensions", "number", ["string"]),
-            setKeyboardEnabled: this.Module.cwrap("ejs_set_keyboard_enabled", "null", ["number"])
+            setKeyboardEnabled: this.Module.cwrap("ejs_set_keyboard_enabled", "null", ["number"]),
+            setControllerPortDevice: this.Module.cwrap("ejs_set_controller_port_device", "null", ["number", "number"]),
+            getControllerPortInfo: this.Module.cwrap("ejs_get_controller_port_info", "string", [])
         }
 
         this.writeFile("/home/web_user/.config/retroarch/retroarch.cfg", this.getRetroArchCfg());
@@ -416,6 +418,12 @@ IF EXIST AUTORUN.BAT CALL AUTORUN.BAT
     }
     supportsStates() {
         return !!this.functions.supportsStates();
+    }
+    setControllerPortDevice(port, device) {
+        this.functions.setControllerPortDevice(port, device);
+    }
+    getControllerPortInfo() {
+        return this.functions.getControllerPortInfo();
     }
     getSaveFile(save) {
         if (save !== false) {

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -1614,7 +1614,7 @@ class EmulatorJS {
         this.elements.contextmenu.classList.add("ejs_context_menu");
         this.addEventListener(this.game, "contextmenu", (e) => {
             e.preventDefault();
-            if ((this.config.buttonOpts && this.config.buttonOpts.rightClick === false) || !this.started) return;
+            if ((this.config.buttonOpts && this.config.buttonOpts.rightClick === false) || !this.started || this.lightgunActive) return;
             const parentRect = this.elements.parent.getBoundingClientRect();
             this.elements.contextmenu.style.display = "block";
             const rect = this.elements.contextmenu.getBoundingClientRect();
@@ -1629,6 +1629,19 @@ class EmulatorJS {
         this.addEventListener(this.elements.contextmenu, "contextmenu", (e) => e.preventDefault());
         this.addEventListener(this.elements.parent, "contextmenu", (e) => e.preventDefault());
         this.addEventListener(this.game, "mousedown touchend", hideMenu);
+        // Prevent mouse buttons 4/5 (back/forward) from navigating away
+        // when used as lightgun Start/Select. Works in Chromium-based
+        // browsers; Firefox handles back/forward navigation before page
+        // event handlers fire, so this has no effect there.
+        // See: https://support.mozilla.org/en-US/questions/1319892
+        for (const evtName of ["mousedown", "mouseup", "auxclick"]) {
+            this.addEventListener(this.game, evtName, (e) => {
+                if (this.lightgunActive && (e.button === 3 || e.button === 4)) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            });
+        }
         const parent = this.createElement("ul");
         const addButton = (title, hidden, functi0n) => {
             //<li><a href="#" onclick="return false">'+title+'</a></li>
@@ -4768,6 +4781,27 @@ class EmulatorJS {
             this.enableMouseLock = (value === "enabled");
         } else if (option === "autofireInterval") {
             this.defaultAutoFireInterval = parseInt(value);
+        } else if (option.startsWith("controller-port-device-p")) {
+            const port = parseInt(option.replace("controller-port-device-p", "")) - 1;
+            const deviceId = parseInt(value);
+            this.gameManager.setControllerPortDevice(port, deviceId);
+            /* RETRO_DEVICE_LIGHTGUN = 4; subclass mask = 0xFF */
+            const isLightgun = (deviceId & 0xFF) === 4;
+            if (isLightgun) {
+                this.lightgunActive = true;
+            } else {
+                /* Re-check all ports */
+                this.lightgunActive = false;
+                for (const k in this.allSettings) {
+                    if (k.startsWith("controller-port-device-p")) {
+                        const v = parseInt(this.allSettings[k]);
+                        if ((v & 0xFF) === 4) this.lightgunActive = true;
+                    }
+                }
+            }
+            if (this.canvas) {
+                this.canvas.style.cursor = this.lightgunActive ? "none" : "";
+            }
         }
     }
     menuOptionChanged(option, value) {
@@ -5442,6 +5476,39 @@ class EmulatorJS {
         }, "100", inputOptions, true);
 
         checkForEmptyMenu(inputOptions);
+
+        let controllerPortInfo;
+        try {
+            controllerPortInfo = this.gameManager.getControllerPortInfo();
+        } catch(e) {
+            if (this.debug) console.warn("getControllerPortInfo not available:", e);
+        }
+        if (controllerPortInfo) {
+            // Parse the port info: each line is "port:deviceId:description"
+            const ports = {};
+            controllerPortInfo.split("\n").forEach(line => {
+                if (!line.trim()) return;
+                const parts = line.split(":");
+                if (parts.length < 3) return;
+                const port = parseInt(parts[0]);
+                const deviceId = parts[1];
+                const desc = parts.slice(2).join(":");
+                if (!ports[port]) ports[port] = {};
+                ports[port][deviceId] = this.localization(desc);
+            });
+            const portKeys = Object.keys(ports);
+            if (portKeys.length > 0) {
+                const controllerDeviceOpts = createSettingParent(true, "Controller Port Devices", home);
+                for (const port of portKeys) {
+                    const portNum = parseInt(port) + 1;
+                    if (Object.keys(ports[port]).length <= 1) continue;
+                    addToMenu(this.localization("Port") + " " + portNum,
+                        "controller-port-device-p" + portNum,
+                        ports[port], "1", controllerDeviceOpts, true);
+                }
+                checkForEmptyMenu(controllerDeviceOpts);
+            }
+        }
 
         if (this.saveInBrowserSupported()) {
             const saveStateOpts = createSettingParent(true, "Save States", home);


### PR DESCRIPTION
Hi, all.

Over the weekend I embedded EmulatorJS in [a project][freeplay], and realized that lightgun support was not implemented. This is one of two PRs that implements it. (You can see it working now in the linked project - I've applied these patches there already.) I'll open the corresponding PR in EmulatorJS momentarily.

I am a software engineer, but I am not a C programmer, so please take a close look at this one. That said, the I've robustly tested the changes (meaning: I've beaten _Battleclash_ and _Metal Combat: Falcon's Revenge_ several times today, lol), and I've encountered no issues.

I hope this is helpful. I'm happy to answer any questions.

### Summary

Adds a "Controller Port Devices" section to the settings menu, allowing users to change each port's device type at runtime. This enables lightgun support for SNES Super Scope, Justifier, NES Zapper, PSX GunCon, and other peripherals that require a non-default device type.

This has been a requested feature for several years (#272, #677, #816, #1117). The maintainer noted in #816:

> "we do also need to pass device ids to retroarch for lightgun/mouse related items too in the end"

### How it works

The available device types are queried from the core at runtime via a new `ejs_get_controller_port_info()` WASM export (provided by a companion PR to EmulatorJS/RetroArch). The settings menu dynamically populates a dropdown per port with the available options. Selecting a device type calls `ejs_set_controller_port_device()` to tell the core.

For example, snes9x reports these device types for Port 2:

- Joypad
- Mouse
- Multitap
- Super Scope
- Justifier
- M.A.C.S. Rifle

### Lightgun UX

When a lightgun device is selected:

- Mouse cursor is hidden over the game canvas
- Right-click context menu is suppressed (right-click is used as a lightgun button)
- Browser back/forward on mouse buttons 4/5 is prevented (Chromium only; Firefox handles this at the browser level)

### Graceful degradation

When paired with older RetroArch WASM builds that lack the new exports, the `cwrap` calls succeed but the function calls are caught. The "Controller Port Devices" section simply doesn't appear in settings.

### Testing

Tested with snes9x core running SNES Super Scope games (Battle Clash, Metal Combat, Super Scope 6). Full playthrough of Battle Clash completed successfully. Crosshair tracks mouse, all Super Scope buttons functional, device selection persists across sessions.

One note: unfortunately the Pause button does not work properly in Firefox (etc) due to an implementation detail in the browser. See the inline comment for details. Realistically, most Super Scope games are perfectly playable without that button. (And Chromium-based browser work perfectly.)

### Companion PR

This PR depends upon RetroArch changes implemented here:  
https://github.com/EmulatorJS/RetroArch/pull/38

### Closes

- #677

### Related

- #272
- #816
- #1117

[freeplay]: https://github.com/chrisallenlane/freeplay