### PR TITLE
Fixed opposing axis value being retained if not passing trough deadzone

### DIFF
--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -3786,13 +3786,19 @@ class EmulatorJS {
         if (gamepadIndex < 0) {
             return; // Gamepad not set anywhere
         }
-        const value = function (value) {
-            if (value > 0.5 || value < -0.5) {
-                return (value > 0) ? 1 : -1;
-            } else {
-                return 0;
-            }
-        }(e.value || 0);
+
+        const toIntValue = (value) => {
+          if (value > 0.5 || value < -0.5) {
+              return (value > 0) ? 1 : -1;
+          } else {
+              return 0;
+          }
+        };
+
+        const value = toIntValue(e.value || 0);
+        const oldValue = toIntValue(e.oldValue || 0);
+        const skippedZero = (value !== 0) && (value + oldValue === 0);
+
         if (this.controlPopup.parentElement.parentElement.getAttribute("hidden") === null) {
             if ("buttonup" === e.type || (e.type === "axischanged" && value === 0)) return;
             const num = this.controlPopup.getAttribute("button-num");
@@ -3865,6 +3871,8 @@ class EmulatorJS {
                             }
                         } else if (value === 0 || controlValue === e.label || controlValue === `${e.axis}:${value}`) {
                             this.gameManager.simulateInput(i, j, ((value === 0) ? 0 : 1));
+                        } else if (skippedZero) {
+                          this.gameManager.simulateInput(i, j, 0);
                         }
                     }
                 }

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -3788,11 +3788,11 @@ class EmulatorJS {
         }
 
         const toIntValue = (value) => {
-          if (value > 0.5 || value < -0.5) {
-              return (value > 0) ? 1 : -1;
-          } else {
-              return 0;
-          }
+            if (value > 0.5 || value < -0.5) {
+                return (value > 0) ? 1 : -1;
+            } else {
+                return 0;
+            }
         };
 
         const value = toIntValue(e.value || 0);
@@ -3872,7 +3872,7 @@ class EmulatorJS {
                         } else if (value === 0 || controlValue === e.label || controlValue === `${e.axis}:${value}`) {
                             this.gameManager.simulateInput(i, j, ((value === 0) ? 0 : 1));
                         } else if (skippedZero) {
-                          this.gameManager.simulateInput(i, j, 0);
+                            this.gameManager.simulateInput(i, j, 0);
                         }
                     }
                 }

--- a/data/src/gamepad.js
+++ b/data/src/gamepad.js
@@ -68,6 +68,7 @@ class GamepadHandler {
                         this.dispatchEvent('axischanged', {
                             axis: axis,
                             value: newVal,
+                            oldValue: val,
                             index: gamepad.index,
                             label: this.getAxisLabel(axis, newVal),
                             gamepadIndex: gamepad.index,


### PR DESCRIPTION
**Summary**
This PR fixes a bug where an axis value is retained when it "jumps" directly between opposing maximums (e.g., -1 to 1) without passing through the deadzone (0).

**Problem**
This can occur with controllers that simulate analog sticks via a D-Pad (like the 8BitDo SF/C 30). When a user switches directions instantly (e.g., Left to Right), the input value might jump from -1 directly to 1.
Because the value never hits 0, the logic fails to reset the previous direction's state. This results in both opposing axis values (e.g., LEFT_STICK_X:+1 and LEFT_STICK_X:-1) being active simultaneously, which is physically impossible for a standard stick.

**Fix**
Added a check to detect these direct transitions. If the value jumps from one extreme to the other, the opposite direction is now manually forced to 0.