### PR TITLE
Fixes for extracting archives handled by cores and fix for EJS_loadStateURL

### DIFF
--- a/data/src/GameManager.js
+++ b/data/src/GameManager.js
@@ -90,19 +90,29 @@ class EJS_GameManager {
                     await new Promise(async (done) => {
                         try {
                             const url = this.EJS.config.externalFiles[key];
-                            const cacheItem = await this.EJS.downloadFile(url, this.EJS.downloadType.support.name, "GET", {}, null, null, null, 30000, "arraybuffer", false, this.EJS.downloadType.support.dontCache);
+                            
+                            const cacheItem = await this.EJS.downloadFile(
+                                url,
+                                this.EJS.downloadType.support.name,
+                                null,          // progress callback
+                                true,          // notWithPath (URL is already absolute)
+                                { responseType: "arraybuffer" },  // opts (was null → causes crash)
+                                false,         // forceExtract
+                                this.EJS.downloadType.support.dontCache,
+                                false          // dontExtract
+                            );
                             
                             let path = key;
                             if (key.trim().endsWith("/")) {
                                 // Extract to directory
-                                for (let i = 0; i < cacheItem.files.length; i++) {
-                                    const file = cacheItem.files[i];
+                                for (let i = 0; i < cacheItem.data.files.length; i++) {
+                                    const file = cacheItem.data.files[i];
                                     this.writeFile(path + file.filename, file.bytes);
                                 }
                             } else {
                                 // Write single file (or first file from archive)
-                                if (cacheItem.files.length > 0) {
-                                    this.writeFile(path, cacheItem.files[0].bytes);
+                                if (cacheItem.data.files.length > 0) {
+                                    this.writeFile(path, cacheItem.data.files[0].bytes);
                                 }
                             }
                             done();

--- a/data/src/cache.js
+++ b/data/src/cache.js
@@ -2,6 +2,8 @@ import { simpleHash } from "./utils.js";
 import { EJS_STORAGE } from "./storage.js";
 import { EJS_COMPRESSION } from "./compression.js";
 
+const CACHE_BLOB_CHUNK_SIZE = 50 * 1024 * 1024;
+
 /**
  * EJS Download Manager
  * Downloads files from a given URL when a download is requested.
@@ -381,6 +383,206 @@ class EJS_Cache {
     }
 
     /**
+     * Normalizes stored binary data into a Uint8Array for chunking and reconstruction.
+     * @param {Uint8Array|ArrayBuffer|ArrayBufferView} bytes - The stored binary value.
+     * @returns {Uint8Array} A Uint8Array view of the input, or an empty array if unsupported.
+     */
+    normalizeFileBytes(bytes) {
+        if (bytes instanceof Uint8Array) return bytes;
+        if (bytes instanceof ArrayBuffer) return new Uint8Array(bytes);
+        if (ArrayBuffer.isView(bytes)) {
+            return new Uint8Array(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+        }
+        return new Uint8Array(0);
+    }
+
+    /**
+     * Opens the raw IndexedDB object store used for blob payload records.
+     * @param {IDBTransactionMode} [mode="readwrite"] - The transaction mode to open the store with.
+     * @returns {Promise<IDBObjectStore|null>} The blob object store, or null when storage is unavailable.
+     */
+    async getBlobObjectStore(mode = "readwrite") {
+        if (!this.blobStorage) return null;
+        return await this.blobStorage.getObjectStore(mode);
+    }
+
+    /**
+     * Writes a single blob manifest part or chunk record into the blobs store.
+     * @param {string} key - The IndexedDB key for the record.
+     * @param {*} value - The value to persist for that record.
+     * @returns {Promise<void>}
+     */
+    async putBlobEntry(key, value) {
+        const objectStore = await this.getBlobObjectStore();
+        if (!objectStore) return;
+        return await new Promise(resolve => {
+            const request = objectStore.put(value, key);
+            request.onsuccess = () => resolve();
+            request.onerror = () => resolve();
+        });
+    }
+
+    /**
+     * Reads a single blob manifest part or chunk record from the blobs store.
+     * @param {string} key - The IndexedDB key for the record.
+     * @returns {Promise<*|null>} The stored value, or null if it is missing.
+     */
+    async getBlobEntry(key) {
+        const objectStore = await this.getBlobObjectStore("readonly");
+        if (!objectStore) return null;
+        return await new Promise(resolve => {
+            const request = objectStore.get(key);
+            request.onsuccess = () => resolve(request.result ?? null);
+            request.onerror = () => resolve(null);
+        });
+    }
+
+    /**
+     * Collects every blob-store key referenced by a cached manifest.
+     * @param {string} key - The parent cache key for the manifest.
+     * @param {*} manifest - The stored blob manifest for that cache key.
+     * @returns {Set<string>} All keys that should be preserved during cleanup.
+     */
+    getBlobManifestKeys(key, manifest) {
+        const referencedKeys = new Set([key]);
+        if (!manifest?._ejsBlobManifest || !Array.isArray(manifest.files)) return referencedKeys;
+
+        for (const file of manifest.files) {
+            if (!file?.key) continue;
+            if (file.type === "chunked") {
+                for (let i = 0; i < file.chunkCount; i++) {
+                    referencedKeys.add(`${file.key}__chunk__${i}`);
+                }
+            } else {
+                referencedKeys.add(file.key);
+            }
+        }
+
+        return referencedKeys;
+    }
+
+    /**
+     * Deletes a single blob manifest part or chunk record from the blobs store.
+     * @param {string} key - The IndexedDB key for the record.
+     * @returns {Promise<void>}
+     */
+    async removeBlobEntry(key) {
+        const objectStore = await this.getBlobObjectStore();
+        if (!objectStore) return;
+        return await new Promise(resolve => {
+            const request = objectStore.delete(key);
+            request.onsuccess = () => resolve();
+            request.onerror = () => resolve();
+        });
+    }
+
+    /**
+     * Stores a cache item's file list in the blobs store, chunking large payloads as needed.
+     * @param {string} key - The parent cache key for the file list.
+     * @param {EJS_FileItem[]} files - The files to persist for the cache item.
+     * @returns {Promise<void>}
+     */
+    async storeBlobFiles(key, files) {
+        const manifest = {
+            _ejsBlobManifest: true,
+            files: []
+        };
+
+        for (let i = 0; i < files.length; i++) {
+            const file = files[i];
+            const fileKey = `${key}__blob__${i}`;
+            const bytes = this.normalizeFileBytes(file?.bytes);
+
+            if (bytes.byteLength > CACHE_BLOB_CHUNK_SIZE) {
+                const totalChunks = Math.ceil(bytes.byteLength / CACHE_BLOB_CHUNK_SIZE);
+                for (let j = 0; j < totalChunks; j++) {
+                    const start = j * CACHE_BLOB_CHUNK_SIZE;
+                    const end = Math.min(start + CACHE_BLOB_CHUNK_SIZE, bytes.byteLength);
+                    await this.putBlobEntry(`${fileKey}__chunk__${j}`, bytes.slice(start, end));
+                }
+                manifest.files.push({
+                    filename: file?.filename,
+                    type: "chunked",
+                    key: fileKey,
+                    chunkCount: totalChunks
+                });
+            } else {
+                await this.putBlobEntry(fileKey, bytes);
+                manifest.files.push({
+                    filename: file?.filename,
+                    type: "single",
+                    key: fileKey
+                });
+            }
+        }
+
+        await this.blobStorage.put(key, manifest);
+    }
+
+    /**
+     * Rebuilds a cache item's file list from blob records and fails fast if any part is missing.
+     * @param {string} key - The parent cache key for the file list.
+     * @returns {Promise<EJS_FileItem[]|null>} The restored files, or null when integrity checks fail.
+     */
+    async getBlobFiles(key) {
+        const stored = await this.blobStorage.get(key);
+        if (!stored) return null;
+        if (Array.isArray(stored)) return stored;
+        if (!stored._ejsBlobManifest || !Array.isArray(stored.files)) return stored;
+
+        const files = [];
+        for (const file of stored.files) {
+            if (file.type === "chunked") {
+                const chunks = [];
+                let totalLength = 0;
+                for (let i = 0; i < file.chunkCount; i++) {
+                    const chunk = await this.getBlobEntry(`${file.key}__chunk__${i}`);
+                    if (chunk === null) return null;
+                    const chunkBytes = this.normalizeFileBytes(chunk);
+                    if (chunkBytes.byteLength === 0) return null;
+                    chunks.push(chunkBytes);
+                    totalLength += chunkBytes.byteLength;
+                }
+                const merged = new Uint8Array(totalLength);
+                let offset = 0;
+                for (const chunk of chunks) {
+                    merged.set(chunk, offset);
+                    offset += chunk.byteLength;
+                }
+                files.push(new EJS_FileItem(file.filename, merged));
+            } else {
+                const blobEntry = await this.getBlobEntry(file.key);
+                if (blobEntry === null) return null;
+                const bytes = this.normalizeFileBytes(blobEntry);
+                if (bytes.byteLength === 0) return null;
+                files.push(new EJS_FileItem(file.filename, bytes));
+            }
+        }
+        return files;
+    }
+
+    /**
+     * Removes a cache item's manifest and all chunk records that belong to it.
+     * @param {string} key - The parent cache key for the file list.
+     * @returns {Promise<void>}
+     */
+    async removeBlobFiles(key) {
+        const stored = await this.blobStorage.get(key);
+        if (stored && stored._ejsBlobManifest && Array.isArray(stored.files)) {
+            for (const file of stored.files) {
+                if (file.type === "chunked") {
+                    for (let i = 0; i < file.chunkCount; i++) {
+                        await this.removeBlobEntry(`${file.key}__chunk__${i}`);
+                    }
+                } else {
+                    await this.removeBlobEntry(file.key);
+                }
+            }
+        }
+        await this.blobStorage.remove(key);
+    }
+
+    /**
      * Retrieves an item from the cache.
      * @param {*} key - The unique key identifying the cached item.
      * @param {boolean} [metadataOnly=false] - If true, only retrieves metadata without file data.
@@ -407,7 +609,12 @@ class EJS_Cache {
 
             if (!metadataOnly) {
                 // get the blob from cache-blobs
-                item.files = await this.blobStorage.get(item.key);
+                item.files = await this.getBlobFiles(item.key);
+                if (!item.files) {
+                    await this.delete(item.key);
+                    await this.cleanup();
+                    return null;
+                }
             }
         }
 
@@ -482,7 +689,7 @@ class EJS_Cache {
         });
 
         // store the files in cache-blobs
-        await this.blobStorage.put(item.key, item.files);
+        await this.storeBlobFiles(item.key, item.files);
     }
 
     /**
@@ -496,7 +703,7 @@ class EJS_Cache {
         // fail silently if the key does not exist
         try {
             await this.storage.remove(key);
-            await this.blobStorage.remove(key);
+            await this.removeBlobFiles(key);
         } catch (e) {
             console.error("Failed to delete cache item:", e);
         }
@@ -559,9 +766,16 @@ class EJS_Cache {
 
         // remove orphaned blobs in blobStorage - here as a failsafe in case of previous incomplete deletions
         const blobKeys = await this.blobStorage.getKeys();
+        const referencedBlobKeys = new Set();
+        for (const item of allItems) {
+            referencedBlobKeys.add(item.key);
+            const blobEntry = await this.blobStorage.get(item.key);
+            for (const blobKey of this.getBlobManifestKeys(item.key, blobEntry)) {
+                referencedBlobKeys.add(blobKey);
+            }
+        }
         for (const blobKey of blobKeys) {
-            const existsInStorage = allItems.find(item => item.key === blobKey);
-            if (!existsInStorage) {
+            if (!referencedBlobKeys.has(blobKey)) {
                 await this.blobStorage.remove(blobKey);
             }
         }
@@ -583,19 +797,20 @@ class EJS_CacheItem {
     /**
      * Creates an instance of EJS_CacheItem.
      * @param {string} key - Unique identifier for the cached item.
-     * @param {EJS_FileItem[]} files - array of EJS_FileItem objects representing the files associated with this cache item.
+     * @param {EJS_FileItem[]} files - Array of EJS_FileItem objects representing the files associated with this cache item.
      * @param {number} added - Timestamp (in milliseconds) when the item was added to the cache.
-     * @param {string} type - The type of cached content (e.g., 'core', 'ROM', 'BIOS', 'decompressed').
+     * @param {string} [type="unknown"] - The type of cached content (e.g., 'core', 'ROM', 'BIOS', 'decompressed').
      * @param {string} responseType - The response type used when downloading the content (e.g., 'arraybuffer', 'blob', 'text').
      * @param {string} filename - The original filename of the cached content.
      * @param {string} url - The URL from which the cached content was downloaded.
      * @param {number|null} cacheExpiry - Timestamp (in milliseconds) indicating when the cache item should expire.
+     * @param {number} [lastAccessed=added] - Timestamp (in milliseconds) when the item was last accessed. Defaults to added.
      */
-    constructor(key, files, added, type = "unknown", responseType, filename, url, cacheExpiry) {
+    constructor(key, files, added, type = "unknown", responseType, filename, url, cacheExpiry, lastAccessed = added) {
         this.key = key;
         this.files = files;
         this.added = added;
-        this.lastAccessed = added;
+        this.lastAccessed = lastAccessed;
         this.type = type;
         this.responseType = responseType;
         this.filename = filename;
@@ -604,8 +819,8 @@ class EJS_CacheItem {
     }
 
     /**
-     * Calculates the total size of all files in this cache item.
-     * @returns {number} - Total size in bytes.
+     * Calculates the total byte size of all files in this cache item.
+     * @returns {number} Total size in bytes.
      */
     size() {
         let total = 0;
@@ -620,13 +835,12 @@ class EJS_CacheItem {
 
 /**
  * EJS_FileItem
- * Represents a single file stored in the cache. This class is an internal structure used by EJS_CacheItem.
+ * Represents a single file within an EJS_CacheItem. Stores the filename and its raw bytes.
  */
 class EJS_FileItem {
     /**
-     * Creates an instance of EJS_FileItem.
-     * @param {string} filename - Name of the file.
-     * @param {Uint8Array} bytes - Byte array representing the file's data.
+     * @param {string} filename - The name of the file (e.g. "game.rom").
+     * @param {Uint8Array} bytes - The raw file contents.
      */
     constructor(filename, bytes) {
         this.filename = filename;

--- a/data/src/cache.js
+++ b/data/src/cache.js
@@ -101,9 +101,10 @@ class EJS_Download {
      * @param {string} responseType - The response type (default is "arraybuffer").
      * @param {boolean} forceExtract - Whether to force extraction of compressed files regardless of extension (default is false).
      * @param {boolean} dontCache - If true, the downloaded file will not be cached (default is false).
+     * @param {boolean} dontExtract - If true, the downloaded file will not be extracted, but will still be cached (default is false, overridden by forceExtract).
      * @returns {Promise<EJS_CacheItem>} - The downloaded file as an EJS_CacheItem.
      */
-    downloadFile(url, type, method = "GET", headers = {}, body = null, onProgress = null, onComplete = null, timeout = 30000, responseType = "arraybuffer", forceExtract = false, dontCache = false) {
+    downloadFile(url, type, method = "GET", headers = {}, body = null, onProgress = null, onComplete = null, timeout = 30000, responseType = "arraybuffer", forceExtract = false, dontCache = false, dontExtract = false) {
         let cacheActiveText = " (cache usage requested)"
         if (dontCache) {
             cacheActiveText = "";
@@ -228,7 +229,8 @@ class EJS_Download {
                 let files = [];
                 const ext = filename.toLowerCase().split('.').pop();
                 if (responseType === "arraybuffer") {
-                    if (["zip", "7z", "rar"].includes(ext) || forceExtract) {
+                    if (forceExtract === true || (dontExtract === false && ["zip", "7z", "rar"].includes(ext))) {
+                        console.log(`Extracting ${filename} because it is a compressed file and forceExtract is ${forceExtract} and dontExtract is ${dontExtract}`);
                         if (onProgress) onProgress("decompressing", 0, 0, 0);
                         try {
                             const compression = new EJS_COMPRESSION(this.EJS);
@@ -245,6 +247,7 @@ class EJS_Download {
                             return;
                         }
                     } else {
+                        console.log(`Not extracting ${filename} because forceExtract is ${forceExtract} and dontExtract is ${dontExtract}`);
                         files = [new EJS_FileItem(filename, data instanceof Uint8Array ? data : new Uint8Array(data))];
                     }
                 } else {

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -971,7 +971,9 @@ class EmulatorJS {
                     }
                 }
                 if (fileName.endsWith("/")) {
-                    this.gameManager.FS.mkdir(fileName);
+                    if (!this.gameManager.FS.analyzePath(fileName).exists) {
+                        this.gameManager.FS.mkdir(fileName);
+                    }
                     return null;
                 }
                 this.gameManager.FS.writeFile(`/${fileName}`, fileData);

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -74,9 +74,10 @@ class EmulatorJS {
      * @param {*} opts Additional options for the download.
      * @param {boolean} forceExtract Whether to force extraction of compressed files regardless of extension (default is false).
      * @param {boolean} dontCache If true, the downloaded file will not be cached (default is false).
+     * @param {boolean} dontExtract If true, the downloaded file will not be extracted, but will still be cached (default is false, overridden by forceExtract).
      * @returns A promise that resolves with the downloaded file data.
      */
-    downloadFile(path, type, progress, notWithPath, opts, forceExtract = false, dontCache = false) {
+    downloadFile(path, type, progress, notWithPath, opts, forceExtract = false, dontCache = false, dontExtract = false) {
         if (this.debug) console.log("[EJS " + type + "] Downloading " + path);
         return new Promise(async (resolve) => {
             // Handle direct data objects (ArrayBuffer, Uint8Array, Blob)
@@ -130,7 +131,8 @@ class EmulatorJS {
                     timeout,
                     responseType,
                     forceExtract,
-                    dontCache
+                    dontCache,
+                    dontExtract
                 );
 
                 // Handle HEAD requests (returns null)
@@ -360,9 +362,9 @@ class EmulatorJS {
         
         // Populate downloadTypes
         this.downloadType = {
-            "rom": { "name": "ROM", "dontCache": false },
+            "rom": { "name": "ROM", "dontCache": false, "dontExtractIfCore": ["arcade", "fbneo", "fbalpha2012_cps1", "fbalpha2012_cps2", "same_cdi", "mame", "mame2003_plus", "mame2003"] },
             "core": { "name": "Core", "dontCache": false },
-            "bios": { "name": "BIOS", "dontCache": false },
+            "bios": { "name": "BIOS", "dontCache": false, "dontExtractIfCore": ["arcade", "fbneo", "fbalpha2012_cps1", "fbalpha2012_cps2", "same_cdi", "mame", "mame2003_plus", "mame2003"] },
             "parent": { "name": "Parent", "dontCache": false },
             "patch": { "name": "Patch", "dontCache": false },
             "reports": { "name": "Reports", "dontCache": true },
@@ -850,6 +852,14 @@ class EmulatorJS {
             this.compression = new EJS_COMPRESSION(this);
         }
 
+        let dontExtract = false;
+        if (type.dontExtractIfCore?.includes(this.getCore())) {
+            dontExtract = true;
+            console.log(`[EJS ${type.name.toUpperCase()}] Core ${this.getCore()} requires special handling, will not attempt to extract if compressed.`);
+        } else {
+            console.log(`[EJS ${type.name.toUpperCase()}] Core ${this.getCore()} does not require special handling, will attempt to extract if compressed.`);
+        }
+
         return new Promise(async (resolve, reject) => {
             let returnData;
 
@@ -870,29 +880,34 @@ class EmulatorJS {
                 } else {
                     // Not in cache - decompress
                     let files = [];
-                    const decompressedData = await this.compression.decompress(inData, (m, appendMsg) => {
-                        this.textElem.innerText = appendMsg ? (this.localization("Decompress Game Core") + m) : m;
-                    }, (fileName, fileData) => {
-                        // Use file callback to collect files during decompression
-                        let bytes;
-                        if (fileData instanceof Uint8Array) {
-                            bytes = fileData;
-                        } else if (fileData instanceof ArrayBuffer) {
-                            bytes = new Uint8Array(fileData);
-                        } else if (fileData && typeof fileData === 'object') {
-                            // Handle case where it might be an object with numeric keys
-                            bytes = new Uint8Array(Object.values(fileData));
-                        } else {
-                            console.error("Unknown file data type:", typeof fileData, fileData);
-                            return;
-                        }
+                    if (dontExtract === false) {
+                        const decompressedData = await this.compression.decompress(inData, (m, appendMsg) => {
+                            this.textElem.innerText = appendMsg ? (this.localization("Decompress Game Core") + m) : m;
+                        }, (fileName, fileData) => {
+                            // Use file callback to collect files during decompression
+                            let bytes;
+                            if (fileData instanceof Uint8Array) {
+                                bytes = fileData;
+                            } else if (fileData instanceof ArrayBuffer) {
+                                bytes = new Uint8Array(fileData);
+                            } else if (fileData && typeof fileData === 'object') {
+                                // Handle case where it might be an object with numeric keys
+                                bytes = new Uint8Array(Object.values(fileData));
+                            } else {
+                                console.error("Unknown file data type:", typeof fileData, fileData);
+                                return;
+                            }
 
-                        if (fileName === "!!notCompressedData") {
-                            files.push(new EJS_FileItem(url.name, bytes));
-                        } else if (!fileName.endsWith("/")) {
-                            files.push(new EJS_FileItem(fileName, bytes));
-                        }
-                    });
+                            if (fileName === "!!notCompressedData") {
+                                files.push(new EJS_FileItem(url.name, bytes));
+                            } else if (!fileName.endsWith("/")) {
+                                files.push(new EJS_FileItem(fileName, bytes));
+                            }
+                        });
+                    } else {
+                        // If we shouldn't extract, just treat the whole file as a single item
+                        files.push(new EJS_FileItem(url.name, inData));
+                    }
 
                     // construct EJS_CacheItem
                     let data = new EJS_CacheItem(
@@ -923,7 +938,8 @@ class EmulatorJS {
                     true,
                     { responseType: "arraybuffer", method: "GET" },
                     false,
-                    type.dontCache
+                    type.dontCache,
+                    dontExtract
                 );
                 // check for error
                 if (data === -1) {

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -824,7 +824,7 @@ class EmulatorJS {
                 }
                 this.on("start", () => {
                     setTimeout(() => {
-                        this.gameManager.loadState(new Uint8Array(res.data));
+                        this.gameManager.loadState(new Uint8Array(res.data.files[0].bytes));
                     }, 10);
                 })
                 resolve();

--- a/data/src/storage.js
+++ b/data/src/storage.js
@@ -1,14 +1,25 @@
+/**
+ * Thin wrapper around a single IndexedDB object store.
+ * Handles opening the database and provides get/put/remove/getAll helpers.
+ * Each instance is scoped to one store name within a named database.
+ */
 class EJS_STORAGE {
     /**
-     * @param {string} dbName
-     * @param {string} storeName
-     * @param {string[]?} indexes - Optional array of field names to create non-unique indexes on
+     * @param {string} dbName - The IndexedDB database name to open.
+     * @param {string} storeName - The object store name to use within that database.
+     * @param {string[]?} indexes - Optional array of field names to create non-unique indexes on.
      */
     constructor(dbName, storeName, indexes = null) {
         this.dbName = dbName;
         this.storeName = storeName;
         this.indexes = indexes;
     }
+    /**
+     * Tracks which primary keys have stored data by maintaining a `?EJS_KEYS!` index record.
+     * Called internally after every put or remove. Skipped for the index record itself.
+     * @param {string} key - The primary key that was added or removed.
+     * @param {boolean} add - True to register the key, false to deregister it.
+     */
     addFileToDB(key, add) {
         (async () => {
             if (key === "?EJS_KEYS!") return;
@@ -23,6 +34,12 @@ class EJS_STORAGE {
             this.put("?EJS_KEYS!", keys);
         })();
     }
+    /**
+     * Opens the database and resolves with the named object store inside a new transaction.
+     * Resolves with undefined instead of rejecting when IndexedDB is unavailable.
+     * @param {IDBTransactionMode} [mode="readwrite"] - The transaction mode to use.
+     * @returns {Promise<IDBObjectStore|undefined>} The opened object store, or undefined on failure.
+     */
     getObjectStore(mode = "readwrite") {
         return new Promise((resolve, reject) => {
             if (!window.indexedDB) return resolve();
@@ -82,6 +99,12 @@ class EJS_STORAGE {
             }
         });
     }
+    /**
+     * Stores a value under the given primary key and registers the key in the index.
+     * @param {string} key - The primary key to store the value under.
+     * @param {*} data - The value to persist.
+     * @returns {Promise<void>}
+     */
     put(key, data) {
         return new Promise(async (resolve, reject) => {
             const objectStore = await this.getObjectStore();
@@ -94,6 +117,11 @@ class EJS_STORAGE {
             };
         });
     }
+    /**
+     * Deletes the record for the given key and removes it from the index.
+     * @param {string} key - The primary key to delete.
+     * @returns {Promise<void>}
+     */
     remove(key) {
         return new Promise(async (resolve, reject) => {
             const objectStore = await this.getObjectStore();
@@ -104,6 +132,10 @@ class EJS_STORAGE {
             request.onerror = () => {};
         });
     }
+    /**
+     * Returns a map of primary key → byte length for every tracked record that has a `.data` ArrayBuffer.
+     * @returns {Promise<Object.<string, number>>} Map of key to byte size.
+     */
     getSizes() {
         return new Promise(async (resolve, reject) => {
             if (!window.indexedDB) resolve({});
@@ -118,6 +150,10 @@ class EJS_STORAGE {
             resolve(rv);
         })
     }
+    /**
+     * Retrieves every tracked record in the store as an array.
+     * @returns {Promise<any[]>} Array of all stored values, excluding the key index record.
+     */
     getAll() {
         return new Promise(async (resolve, reject) => {
             if (!window.indexedDB) return resolve([]);
@@ -132,6 +168,10 @@ class EJS_STORAGE {
             resolve(rv);
         });
     }
+    /**
+     * Returns all tracked primary keys in the store.
+     * @returns {Promise<string[]>} Array of primary keys, excluding the internal index key.
+     */
     getKeys() {
         return new Promise(async (resolve, reject) => {
             if (!window.indexedDB) return resolve([]);
@@ -142,20 +182,29 @@ class EJS_STORAGE {
     }
 }
 
+/**
+ * No-op storage class used as a drop-in replacement for EJS_STORAGE when IndexedDB
+ * is disabled or unavailable. All methods resolve immediately with empty results.
+ */
 class EJS_DUMMYSTORAGE {
     constructor() {}
+    /** @returns {Promise<void>} */
     addFileToDB() {
         return new Promise(resolve => resolve());
     }
+    /** @returns {Promise<undefined>} */
     get() {
         return new Promise(resolve => resolve());
     }
+    /** @returns {Promise<void>} */
     put() {
         return new Promise(resolve => resolve());
     }
+    /** @returns {Promise<void>} */
     remove() {
         return new Promise(resolve => resolve());
     }
+    /** @returns {Promise<{}>} */
     getSizes() {
         return new Promise(resolve => resolve({}));
     }


### PR DESCRIPTION
This PR resolves two issues:
- EJS_loadStateURL was unable to load states correctly
- All archives were being extracted and cached - this PR adds exceptions for FBNEO and MAME as they both require some ROM files to be in zip archives

Cores requiring zip archives to NOT be extracted are defined in the downloadType array using the `dontExtractIfCore` attribbute:
```javascript
this.downloadType = {
            "rom": { "name": "ROM", "dontCache": false, "dontExtractIfCore": ["arcade", "fbneo", "fbalpha2012_cps1", "fbalpha2012_cps2", "same_cdi", "mame", "mame2003_plus", "mame2003"] },
            "core": { "name": "Core", "dontCache": false },
            "bios": { "name": "BIOS", "dontCache": false, "dontExtractIfCore": ["arcade", "fbneo", "fbalpha2012_cps1", "fbalpha2012_cps2", "same_cdi", "mame", "mame2003_plus", "mame2003"] },
            "parent": { "name": "Parent", "dontCache": false },
            "patch": { "name": "Patch", "dontCache": false },
            "reports": { "name": "Reports", "dontCache": true },
            "states": { "name": "States", "dontCache": true },
            "support": { "name": "Support", "dontCache": true },
            "unknown": { "name": "Unknown", "dontCache": true }
        }
```