### PR TITLE
Add Integer Scaling

### DIFF
--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -4573,6 +4573,19 @@ class EmulatorJS {
         //This wouldnt work using :not()... strange.
         this.game.parentElement.classList.toggle("ejs_big_screen", positionInfo.width > 575);
 
+        let intScaleValue = this.getSettingValue("integerScaleFactor")
+        if (!isNaN(intScaleValue)) {
+            let intScaleFactor = parseInt(intScaleValue);
+            let newSize = [intScaleFactor * this.gameManager.getVideoDimensions("width"), intScaleFactor * this.gameManager.getVideoDimensions("width")];
+            this.canvas.style.width =  `${newSize[0]}px`;
+            this.canvas.style.height = `${newSize[1]}px`;
+            this.canvas.width =  `${newSize[0]}`;
+            this.canvas.height = `${newSize[1]}`;
+        } else {
+            this.canvas.style.width =  "";
+            this.canvas.style.height = "";
+        }
+
         if (!this.handleSettingsResize) return;
         this.handleSettingsResize();
     }
@@ -5299,6 +5312,20 @@ class EmulatorJS {
             "2": "180 deg",
             "3": "270 deg"
         }, this.videoRotation.toString(), graphicsOptions, true);
+
+        addToMenu(this.localization("Integer Scaling"), "integerScaleFactor", {
+            "disabled": this.localization("Disabled"),
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7",
+            "8": "8",
+            "9": "9",
+            "10": "10"
+        }, "disabled", graphicsOptions, true)
 
         const screenCaptureOptions = createSettingParent(true, "Screen Capture", home);
 


### PR DESCRIPTION
Pretty basic implementation of integer scaling. There are still a few problems with it, though. 

1. It only works if the pixels are square. Using it on consoles like the NES and SNES that have rectangular pixels will result in uneven pixels (the exact thing integer scaling is meant to prevent). Setting their aspects to pixel-perfect and uncorrected respectively will fix this, but that's obviously not an optimal solution.
2. Effects generated by the core (i.e. snes9x blargg, fceumm ntsc filter) will make the canvas far too big, as they increase the size of the video  

These 2 should be able to be fixed by using a different method of getting the size of the video stream.


3. The canvas won't resize if the video changes sizes (i.e. SNES changing to mode 5, PSX changing resolution)
4. The canvas is pinned to the top-right while integer scaling is enabled

This PR would resolve issue #1100 

