### PR TITLE
Fix gamepad lookup when browser gamepad index is sparse

### DIFF
--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -1343,17 +1343,19 @@ class EmulatorJS {
         this.gamepad = new GamepadHandler(); //https://github.com/ethanaobrien/Gamepad
         this.gamepad.on("connected", (e) => {
             if (!this.gamepadLabels) return;
+            const gamepadSelection = this.getGamepadSelectionValue(e.gamepadIndex);
+            if (!gamepadSelection) return;
             for (let i = 0; i < this.gamepadSelection.length; i++) {
                 if (this.gamepadSelection[i] === "") {
-                    this.gamepadSelection[i] = this.gamepad.gamepads[e.gamepadIndex].id + "_" + this.gamepad.gamepads[e.gamepadIndex].index;
+                    this.gamepadSelection[i] = gamepadSelection;
                     break;
                 }
             }
             this.updateGamepadLabels();
         })
         this.gamepad.on("disconnected", (e) => {
-            const gamepadIndex = this.gamepad.gamepads.indexOf(this.gamepad.gamepads.find(f => f.index == e.gamepadIndex));
-            const gamepadSelection = this.gamepad.gamepads[gamepadIndex].id + "_" + this.gamepad.gamepads[gamepadIndex].index;
+            const gamepadSelection = this.getGamepadSelectionValue(e.gamepadIndex);
+            if (!gamepadSelection) return;
             for (let i = 0; i < this.gamepadSelection.length; i++) {
                 if (this.gamepadSelection[i] === gamepadSelection) {
                     this.gamepadSelection[i] = "";
@@ -1392,6 +1394,13 @@ class EmulatorJS {
             }
             this.gamepadLabels[i].value = this.gamepadSelection[i] || "notconnected";
         }
+    }
+    getGamepadSelectionValue(gamepadIndex) {
+        const gamepad = this.gamepad.gamepads.find((candidate) => candidate && candidate.index === gamepadIndex);
+        if (!gamepad) {
+            return null;
+        }
+        return gamepad.id + "_" + gamepad.index;
     }
     createLink(elem, link, text, useP) {
         const elm = this.createElement("a");
@@ -3862,7 +3871,11 @@ class EmulatorJS {
     }
     gamepadEvent(e) {
         if (!this.started) return;
-        const gamepadIndex = this.gamepadSelection.indexOf(this.gamepad.gamepads[e.gamepadIndex].id + "_" + this.gamepad.gamepads[e.gamepadIndex].index);
+        const gamepadSelection = this.getGamepadSelectionValue(e.gamepadIndex);
+        if (!gamepadSelection) {
+            return;
+        }
+        const gamepadIndex = this.gamepadSelection.indexOf(gamepadSelection);
         if (gamepadIndex < 0) {
             return; // Gamepad not set anywhere
         }


### PR DESCRIPTION
`GamepadHandler` emits `gamepad.index`, but `emulator.js` was treating that value as an array position in `this.gamepad.gamepads`. In Chromium, `navigator.getGamepads()` can use sparse indexes, so this could resolve to undefined and crash on `.id`.

Here's the error I was getting on v4.2.3:

```
emulator.js:1149 Uncaught TypeError: Cannot read properties of undefined (reading 'id')
    at Object.connected (emulator.js:1149:86)
    at GamepadHandler.dispatchEvent (gamepad.js:136:29)
    at gamepad.js:111:22
    at Array.forEach (<anonymous>)
    at GamepadHandler.updateGamepadState (gamepad.js:50:18)
    at GamepadHandler.loop (gamepad.js:36:14)
```

This change looks up gamepads by their actual index instead of array position, and applies the same fix to the `connected`, `disconnected`, and `gamepadEvent` paths.

Result: gamepad handling works consistently across Chromium, Safari, and Firefox.

Disclosure: this fix was vibe coded with ChatGPT 5.4. It might not be the best approach. This is simply a demonstration of a fix that worked for me.