### PR TITLE
Fix resume prompt detection on iPadOS Safari

### DIFF
--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -1201,8 +1201,9 @@ class EmulatorJS {
                 }
             }
             this.menu.open();
-            if (this.isSafari && this.isMobile) {
-                //Safari is --- funny
+            if (this.isSafari && (this.isMobile || this.hasTouchScreen)) {
+                // iPadOS can use a desktop Safari user agent, so touch support
+                // is a more reliable fallback than mobile user-agent detection.
                 this.checkStarted();
             }
 


### PR DESCRIPTION
# Fix resume prompt detection on iPadOS Safari

## Problem

iPadOS Safari can request desktop websites and expose a macOS-style user agent. In that mode EmulatorJS detects Safari and touch support, but `isMobile` is false. The post-start Web Audio recovery check is therefore skipped, leaving an auto-started emulator on a black or frozen frame until the user taps the page without any visible instruction.

## Change

Run `checkStarted()` for Safari when either mobile user-agent detection or touch-screen detection succeeds.

This preserves the existing behavior for iPhone and traditional iPad user agents, does not affect non-Safari touch browsers, and does not show a prompt on desktop Safari because `checkStarted()` only creates the resume control while the audio context is suspended.

## Validation

- Confirmed the issue on iPadOS Safari using a desktop-style user agent.
- Confirmed an unmodified current `main` still gates the check on `isMobile` only.
- Ran ESLint: 0 errors (existing project warnings only).
- Ran `node --check data/src/emulator.js`.
- Ran the official minification build successfully.
- Verified the minified output contains the new condition and not the old condition.
- Regression matrix: iPadOS desktop Safari, iPhone Safari, macOS Safari, Android Chrome touch, Windows Chrome touch, and Windows Chrome.
