### PR TITLE
Add L3/R3 to psx control settings menu

### DIFF
--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -3133,6 +3133,8 @@ class EmulatorJS {
                 { id: 11, label: this.localization("R1") },
                 { id: 12, label: this.localization("L2") },
                 { id: 13, label: this.localization("R2") },
+                { id: 14, label: this.localization("L3") },
+                { id: 15, label: this.localization("R3") },
                 { id: 19, label: this.localization("L STICK UP") },
                 { id: 18, label: this.localization("L STICK DOWN") },
                 { id: 17, label: this.localization("L STICK LEFT") },


### PR DESCRIPTION
## Describe the bug

The psx control scheme (used for `pcsx_rearmed` and `mednafen_psx_hw`) did not expose L3 and R3 (stick-click, button ids 14 and 15) in the Control Settings menu. These inputs are supported by the cores and required by DualShock-era games (e.g. Ape Escape).

This is a regression from v4.2.3: that release has no dedicated psx branch, so PSX fell through to the generic `else` block which includes L3/R3. The newer dedicated psx block added on `main` maps △/□/x/○, L1/R1/L2/R2, and both analog sticks, but dropped L3/R3.

## Fix

Add the two entries after R2 in the psx block of `createControlSettingMenu()` (`data/src/emulator.js`):

```js
{ id: 14, label: this.localization("L3") },
{ id: 15, label: this.localization("R3") },
```

## Expected behavior

L3 and R3 are now listed and bindable, as they were in v4.2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)