### PR TITLE
Enable Core Options v2

### DIFF
--- a/data/src/GameManager.js
+++ b/data/src/GameManager.js
@@ -11,6 +11,7 @@ class EJS_GameManager {
             simulateInput: this.Module.cwrap("simulate_input", "null", ["number", "number", "number"]),
             toggleMainLoop: this.Module.cwrap("toggleMainLoop", "null", ["number"]),
             getCoreOptions: this.Module.cwrap("get_core_options", "string", []),
+            getCoreOptionsJSON: this.Module.cwrap("get_core_options_json", "string", []),
             setVariable: this.Module.cwrap("ejs_set_variable", "null", ["string", "string"]),
             setCheat: this.Module.cwrap("set_cheat", "null", ["number", "number", "string"]),
             resetCheat: this.Module.cwrap("reset_cheat", "null", []),
@@ -398,6 +399,19 @@ IF EXIST AUTORUN.BAT CALL AUTORUN.BAT
     }
     getCoreOptions() {
         return this.functions.getCoreOptions();
+    }
+    // Core options with the data the libretro core options v2 interface provides:
+    // human readable descriptions, value labels, info text and visibility.
+    // Returns null on cores built before get_core_options_json was exported.
+    getCoreOptionsJSON() {
+        if (!this.Module["_get_core_options_json"]) return null;
+        try {
+            const data = JSON.parse(this.functions.getCoreOptionsJSON());
+            return (data && Array.isArray(data.options) && data.options.length) ? data : null;
+        } catch(e) {
+            if (this.EJS.debug) console.warn("Failed to read core options:", e);
+            return null;
+        }
     }
     setVariable(option, value) {
         this.functions.setVariable(option, value);

--- a/data/src/emulator.js
+++ b/data/src/emulator.js
@@ -5227,7 +5227,7 @@ class EmulatorJS {
         }
         let allOpts = {};
 
-        const addToMenu = (title, id, options, defaultOption, parentElement, useParentParent) => {
+        const addToMenu = (title, id, options, defaultOption, parentElement, useParentParent, info) => {
             if (Array.isArray(this.config.hideSettings) && this.config.hideSettings.includes(id)) {
                 return;
             }
@@ -5235,6 +5235,7 @@ class EmulatorJS {
             const transitionElement = useParentParent ? parentElement.parentElement.parentElement : parentElement;
             const menuOption = this.createElement("div");
             menuOption.classList.add("ejs_settings_main_bar");
+            if (info) menuOption.title = info;
             const span = this.createElement("span");
             span.innerText = title;
 
@@ -5637,12 +5638,34 @@ class EmulatorJS {
             checkForEmptyMenu(virtualGamepad);
         }
 
-        let coreOpts;
+        let coreOptsJSON;
         try {
-            coreOpts = this.gameManager.getCoreOptions();
+            coreOptsJSON = this.gameManager.getCoreOptionsJSON();
         } catch(e) {}
-        if (coreOpts) {
-            const coreOptions = createSettingParent(true, "Backend Core Options", home);
+        let coreOpts;
+        if (!coreOptsJSON) {
+            try {
+                coreOpts = this.gameManager.getCoreOptions();
+            } catch(e) {}
+        }
+        if (coreOptsJSON) {
+            const coreOptions = createSettingParent(true, "Core Options", home);
+            coreOptsJSON.options.forEach(option => {
+                if (option.visible === false || option.values.length <= 1) return;
+                const availableOptions = {};
+                option.values.forEach(value => {
+                    availableOptions[value.value] = this.localization(value.label, this.config.settingsLanguage);
+                });
+                addToMenu(this.localization(option.desc || option.key, this.config.settingsLanguage),
+                    option.key, availableOptions,
+                    option.current || option.default,
+                    coreOptions,
+                    true,
+                    option.info ? this.localization(option.info, this.config.settingsLanguage) : null);
+            })
+            checkForEmptyMenu(coreOptions);
+        } else if (coreOpts) {
+            const coreOptions = createSettingParent(true, "Core Options", home);
             coreOpts.split("\n").forEach((line, index) => {
                 let option = line.split("; ");
                 let name = option[0];


### PR DESCRIPTION
Currently, EmulatorJS uses Core Options v1, which means that there is just a key, and a value for each variable. This updates it to allow use of Core Options V2, which brings in human readable labels, descriptions, etc.

Enabled by https://github.com/EmulatorJS/RetroArch/pull/45 .

### Before

<img width="652" height="481" alt="Screenshot from 2026-07-25 15-39-09" src="https://github.com/user-attachments/assets/fb6af1a0-0e6c-44b7-a93e-1dbd2acd7acd" />

### After

<img width="839" height="646" alt="Screenshot from 2026-07-25 15-39-34" src="https://github.com/user-attachments/assets/fd2baf9a-21dc-4b6a-88e9-db684ed3681f" />
